### PR TITLE
Fix Linux crash: default wgpu to GL backend instead of Vulkan

### DIFF
--- a/sentrux-bin/src/main.rs
+++ b/sentrux-bin/src/main.rs
@@ -536,6 +536,24 @@ capabilities = ["functions", "classes", "imports"]
             .with_inner_size([1280.0, 800.0])
             .with_title(if sentrux_core::license::current_tier() >= sentrux_core::license::Tier::Pro { "Sentrux Pro" } else { "sentrux" }),
         renderer: eframe::Renderer::Wgpu,
+        wgpu_options: eframe::egui_wgpu::WgpuConfiguration {
+            wgpu_setup: eframe::egui_wgpu::WgpuSetup::CreateNew(eframe::egui_wgpu::WgpuSetupCreateNew {
+                instance_descriptor: eframe::wgpu::InstanceDescriptor {
+                    // Vulkan surface creation via EGL/DRI3 is unreliable on many
+                    // Linux setups; default to GL (still hardware-accelerated).
+                    // Override with WGPU_BACKEND=vulkan if desired.
+                    backends: eframe::wgpu::Backends::from_env()
+                        .unwrap_or(if cfg!(target_os = "linux") {
+                            eframe::wgpu::Backends::GL
+                        } else {
+                            eframe::wgpu::Backends::PRIMARY | eframe::wgpu::Backends::GL
+                        }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

- Default wgpu to `Backends::GL` on Linux instead of `PRIMARY` (Vulkan)
- Non-Linux platforms unchanged (`PRIMARY | GL`)
- Overridable via `WGPU_BACKEND=vulkan` env var

## Motivation

wgpu's Vulkan backend panics on `Surface::configure` on many Linux setups where EGL cannot acquire a DRI3 device. This is a known fragility in the Vulkan-over-EGL surface creation path:

1. The wgpu `Instance` is created successfully
2. A Vulkan `Adapter` is found and `request_adapter` succeeds
3. `request_device` also succeeds — the GPU is reachable
4. But `Surface::configure` panics with "Invalid surface" because EGL/DRI3 cannot map the windowing system surface to the GPU

This panic happens inside winit's event loop, so `catch_unwind` cannot recover the window state. The only reliable fix is to avoid the Vulkan surface path entirely on affected systems.

The GL backend (`Backends::GL`) is **not** software rendering — it uses hardware-accelerated OpenGL via GLX or a working EGL path, and is the standard reliable backend for Linux desktop apps using wgpu.

## Test plan

- [x] Tested on Linux with broken DRI3/EGL — window opens, app fully functional
- [ ] Verify `WGPU_BACKEND=vulkan` override still works on systems with proper Vulkan support
- [ ] Verify no regression on macOS/Windows (compile-time `cfg!(target_os = "linux")` gate)