### PR TITLE
Fix wgpu NoSuitableAdapterFound on Linux

### DIFF
--- a/sentrux-bin/src/main.rs
+++ b/sentrux-bin/src/main.rs
@@ -560,15 +560,8 @@ capabilities = ["functions", "classes", "imports"]
         wgpu_options: eframe::egui_wgpu::WgpuConfiguration {
             wgpu_setup: eframe::egui_wgpu::WgpuSetup::CreateNew(eframe::egui_wgpu::WgpuSetupCreateNew {
                 instance_descriptor: eframe::wgpu::InstanceDescriptor {
-                    // Vulkan surface creation via EGL/DRI3 is unreliable on many
-                    // Linux setups; default to GL (still hardware-accelerated).
-                    // Override with WGPU_BACKEND=vulkan if desired.
                     backends: eframe::wgpu::Backends::from_env()
-                        .unwrap_or(if cfg!(target_os = "linux") {
-                            eframe::wgpu::Backends::GL
-                        } else {
-                            eframe::wgpu::Backends::PRIMARY | eframe::wgpu::Backends::GL
-                        }),
+                        .unwrap_or(eframe::wgpu::Backends::PRIMARY | eframe::wgpu::Backends::GL),
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
## Summary
- Removes Linux-specific override that forced GL-only backend, which fails on systems where EGL adapter creation is unsupported
- Uses `PRIMARY | GL` on all platforms (same as the existing non-Linux path), letting wgpu pick the native backend (Vulkan/Metal/DX12) first with GL as fallback
- Tested on Linux (CachyOS, kernel 6.19.6) — app launches and renders correctly

## Context
The GL-only default was added in v0.3.9 to work around Vulkan surface creation issues, but it breaks on Linux systems without working EGL. Vulkan is well-supported on modern Linux and should be the primary backend.

## Test plan
- [x] `cargo run` on Linux — launches successfully with Vulkan
- [ ] Verify no regression on macOS (PRIMARY includes Metal, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)