### PR TITLE
Refactor CLI from manual arg parsing to clap derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,11 +825,51 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -799,6 +889,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -2226,6 +2322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,6 +3140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3814,6 +3922,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 name = "sentrux"
 version = "0.3.12"
 dependencies = [
+ "clap 4.6.0",
  "eframe",
  "egui",
  "sentrux-core",
@@ -4131,6 +4240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,7 +4467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41f915e075a8a98ad64a5f7be6b7cc1710fc835c5f07e4a3efcaeb013291c00"
 dependencies = [
  "aho-corasick 0.7.20",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "dashmap 4.0.2",
  "dirs 3.0.2",
@@ -4584,6 +4699,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "value-trait"

--- a/sentrux-bin/Cargo.toml
+++ b/sentrux-bin/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 sentrux-core = { path = "../sentrux-core" }
+clap = { version = "4", features = ["derive"] }
 eframe = { workspace = true }
 egui = { workspace = true }
 

--- a/sentrux-bin/src/main.rs
+++ b/sentrux-bin/src/main.rs
@@ -3,13 +3,164 @@
 //! All logic lives in `sentrux-core`. This crate is just the entry point
 //! that wires together the three modes:
 //! - GUI mode (default): interactive treemap/blueprint visualizer
-//! - MCP mode (`--mcp`): Model Context Protocol server for AI agent integration
-//! - Check mode (`check <path>`): CLI architectural rules enforcement
+//! - MCP mode (`sentrux mcp`): Model Context Protocol server for AI agent integration
+//! - Check mode (`sentrux check [path]`): CLI architectural rules enforcement
+//! - Gate mode (`sentrux gate [--save] [path]`): structural regression testing
 
+use clap::{Parser, Subcommand};
 use sentrux_core::analysis;
 use sentrux_core::app;
 use sentrux_core::core;
 use sentrux_core::metrics;
+
+// ---------------------------------------------------------------------------
+// CLI definition
+// ---------------------------------------------------------------------------
+
+fn version_string() -> &'static str {
+    use std::sync::OnceLock;
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION.get_or_init(|| {
+        let edition = if sentrux_core::license::current_tier() >= sentrux_core::license::Tier::Pro { "Pro" } else { "Free" };
+        format!("{} ({})", env!("CARGO_PKG_VERSION"), edition)
+    })
+}
+
+#[derive(Parser)]
+#[command(
+    name = "sentrux",
+    about = "Live codebase visualization and structural quality gate",
+    version = version_string(),
+    arg_required_else_help = false,
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Directory to open in the GUI
+    #[arg(global = false)]
+    path: Option<String>,
+
+    /// Start MCP server (hidden alias for `sentrux mcp`)
+    #[arg(long = "mcp", hide = true)]
+    mcp_flag: bool,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Enforce architectural rules defined in .sentrux/rules.toml
+    Check {
+        /// Directory to check
+        #[arg(default_value = ".")]
+        path: String,
+    },
+
+    /// Structural regression gate — compare against a saved baseline
+    Gate {
+        /// Save current metrics as the new baseline
+        #[arg(long)]
+        save: bool,
+
+        /// Directory to gate
+        #[arg(default_value = ".")]
+        path: String,
+    },
+
+    /// Open the GUI with a pre-loaded directory
+    Scan {
+        /// Directory to visualize
+        path: Option<String>,
+    },
+
+    /// Start the MCP (Model Context Protocol) server for AI agent integration
+    Mcp,
+
+    /// Manage language plugins
+    Plugin {
+        #[command(subcommand)]
+        action: PluginAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum PluginAction {
+    /// List installed plugins
+    List,
+
+    /// Install all standard language plugins
+    AddStandard,
+
+    /// Install a single language plugin from the plugin registry
+    Add {
+        /// Plugin name (e.g. "python", "rust")
+        name: String,
+    },
+
+    /// Remove an installed plugin
+    Remove {
+        /// Plugin name to remove
+        name: String,
+    },
+
+    /// Create a new plugin template
+    Init {
+        /// Language name for the new plugin
+        name: String,
+    },
+
+    /// Validate a plugin directory
+    Validate {
+        /// Path to the plugin directory
+        dir: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() -> eframe::Result<()> {
+    // Auto-install standard plugins on first run
+    auto_install_plugins_if_needed();
+
+    // Non-blocking update check (once per day, background thread)
+    app::update_check::check_for_updates_async(env!("CARGO_PKG_VERSION"));
+
+    let cli = Cli::parse();
+
+    // Hidden --mcp flag for backward compat with MCP client configs
+    if cli.mcp_flag {
+        app::mcp_server::run_mcp_server(None);
+        return Ok(());
+    }
+
+    match cli.command {
+        Some(Command::Check { path }) => {
+            std::process::exit(run_check(&path));
+        }
+        Some(Command::Gate { save, path }) => {
+            std::process::exit(run_gate(&path, save));
+        }
+        Some(Command::Mcp) => {
+            app::mcp_server::run_mcp_server(None);
+            Ok(())
+        }
+        Some(Command::Plugin { action }) => {
+            run_plugin(action);
+            Ok(())
+        }
+        Some(Command::Scan { path }) => {
+            run_gui(path)
+        }
+        None => {
+            run_gui(cli.path)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check
+// ---------------------------------------------------------------------------
 
 /// Run architectural rules check from CLI. Returns exit code.
 fn run_check(path: &str) -> i32 {
@@ -76,15 +227,12 @@ fn print_check_results(
     }
 }
 
-/// Run structural regression gate from CLI. Returns exit code.
-fn run_gate(args: &[String]) -> i32 {
-    let save_mode = args.iter().any(|a| a == "--save");
-    let path = args.iter()
-        .skip(1)
-        .rfind(|a| !a.starts_with('-') && *a != "gate")
-        .map(|s| s.as_str())
-        .unwrap_or(".");
+// ---------------------------------------------------------------------------
+// Gate
+// ---------------------------------------------------------------------------
 
+/// Run structural regression gate from CLI. Returns exit code.
+fn run_gate(path: &str, save_mode: bool) -> i32 {
     let root = std::path::Path::new(path);
     if !root.is_dir() {
         eprintln!("Error: not a directory: {path}");
@@ -183,6 +331,298 @@ fn gate_compare(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+fn run_plugin(action: PluginAction) {
+    match action {
+        PluginAction::List => {
+            let dir = sentrux_core::analysis::plugin::plugins_dir();
+            println!("Plugin directory: {}", dir.as_ref().map_or("(none)".into(), |d| d.display().to_string()));
+            let (loaded, errors) = sentrux_core::analysis::plugin::load_all_plugins();
+            if loaded.is_empty() && errors.is_empty() {
+                println!("No plugins installed.");
+                println!("\nInstall a plugin by placing it in ~/.sentrux/plugins/<name>/");
+            } else {
+                for p in &loaded {
+                    println!("  {} v{} [{}] — {}", p.name, p.version, p.extensions.join(", "), p.display_name);
+                }
+                for e in &errors {
+                    println!("  (error) {} — {}", e.plugin_dir.display(), e.error);
+                }
+            }
+        }
+        PluginAction::Init { name } => {
+            let dir = sentrux_core::analysis::plugin::plugins_dir()
+                .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
+            let plugin_dir = dir.join(&name);
+            if plugin_dir.exists() {
+                eprintln!("Plugin directory already exists: {}", plugin_dir.display());
+                std::process::exit(1);
+            }
+            std::fs::create_dir_all(plugin_dir.join("grammars")).unwrap();
+            std::fs::create_dir_all(plugin_dir.join("queries")).unwrap();
+            std::fs::create_dir_all(plugin_dir.join("tests")).unwrap();
+            std::fs::write(plugin_dir.join("plugin.toml"), format!(r#"[plugin]
+name = "{name}"
+display_name = "{name}"
+version = "0.1.0"
+extensions = ["TODO"]
+min_sentrux_version = "0.1.3"
+
+[plugin.metadata]
+author = ""
+description = ""
+
+[grammar]
+source = "https://github.com/TODO/tree-sitter-{name}"
+ref = "main"
+abi_version = 14
+
+[queries]
+capabilities = ["functions", "classes", "imports"]
+
+[checksums]
+"#)).unwrap();
+            std::fs::write(plugin_dir.join("queries").join("tags.scm"),
+                ";; TODO: Write tree-sitter queries for this language\n;;\n;; Required captures:\n;;   @func.def / @func.name — function definitions\n;;   @class.def / @class.name — class definitions\n;;   @import.path — import statements\n;;   @call.name — function calls (optional)\n"
+            ).unwrap();
+            println!("Created plugin template at {}", plugin_dir.display());
+            println!("\nNext steps:");
+            println!("  1. Edit plugin.toml — set extensions, grammar source");
+            println!("  2. Build the grammar: tree-sitter generate && cc -shared -o grammars/{} src/parser.c",
+                sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename());
+            println!("  3. Write queries/tags.scm");
+            println!("  4. Test: sentrux plugin validate {}", plugin_dir.display());
+        }
+        PluginAction::Validate { dir } => {
+            let plugin_dir = std::path::Path::new(&dir);
+            print!("Validating {}... ", plugin_dir.display());
+            match sentrux_core::analysis::plugin::manifest::PluginManifest::load(plugin_dir) {
+                Ok(manifest) => {
+                    println!("plugin.toml OK");
+                    println!("  name: {}", manifest.plugin.name);
+                    println!("  version: {}", manifest.plugin.version);
+                    println!("  extensions: [{}]", manifest.plugin.extensions.join(", "));
+                    println!("  capabilities: [{}]", manifest.queries.capabilities.join(", "));
+                    let query_path = plugin_dir.join("queries").join("tags.scm");
+                    match std::fs::read_to_string(&query_path) {
+                        Ok(qs) => {
+                            match manifest.validate_query_captures(&qs) {
+                                Ok(()) => println!("  queries/tags.scm: OK (captures valid)"),
+                                Err(e) => println!("  queries/tags.scm: FAIL — {}", e),
+                            }
+                        }
+                        Err(e) => println!("  queries/tags.scm: MISSING — {}", e),
+                    }
+                    let gf = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
+                    let gp = plugin_dir.join("grammars").join(gf);
+                    if gp.exists() {
+                        println!("  grammars/{}: OK", gf);
+                    } else {
+                        println!("  grammars/{}: MISSING — build the grammar first", gf);
+                    }
+                }
+                Err(e) => {
+                    println!("FAIL — {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        PluginAction::AddStandard => {
+            let standard = [
+                "python", "javascript", "typescript", "rust", "go",
+                "c", "cpp", "java", "ruby", "csharp", "php", "bash",
+                "html", "css", "scss", "swift", "lua", "scala",
+                "elixir", "haskell", "zig", "r", "ocaml",
+            ];
+            let dir = sentrux_core::analysis::plugin::plugins_dir()
+                .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
+            std::fs::create_dir_all(&dir).unwrap();
+            let platform = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
+            let platform_key = platform.rsplit_once('.').map_or(platform, |(k, _)| k);
+            let mut installed = 0;
+            let mut skipped = 0;
+            for name in &standard {
+                let plugin_dir = dir.join(name);
+                if plugin_dir.exists() {
+                    skipped += 1;
+                    continue;
+                }
+                let url = format!(
+                    "https://github.com/sentrux/plugins/releases/download/{name}-v0.1.0/{name}-{platform_key}.tar.gz"
+                );
+                print!("  Installing {name}...");
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+                let ok = std::process::Command::new("curl")
+                    .args(["-fsSL", &url, "-o"])
+                    .arg(dir.join(format!("{name}.tar.gz")))
+                    .status()
+                    .is_ok_and(|s| s.success());
+                if ok {
+                    let extracted = std::process::Command::new("tar")
+                        .args(["xzf", &format!("{name}.tar.gz")])
+                        .current_dir(&dir)
+                        .status()
+                        .is_ok_and(|s| s.success());
+                    let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
+                    if extracted {
+                        println!(" ok");
+                        installed += 1;
+                    } else {
+                        println!(" failed (extract)");
+                    }
+                } else {
+                    let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
+                    println!(" failed (download)");
+                }
+            }
+            println!("\nInstalled {installed} languages ({skipped} already installed)");
+        }
+        PluginAction::Add { name } => {
+            let dir = sentrux_core::analysis::plugin::plugins_dir()
+                .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
+            let plugin_dir = dir.join(&name);
+            if plugin_dir.exists() {
+                eprintln!("Plugin '{}' already installed at {}", name, plugin_dir.display());
+                eprintln!("Remove it first: sentrux plugin remove {}", name);
+                std::process::exit(1);
+            }
+
+            let platform = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
+            let platform_key = platform.rsplit_once('.').map_or(platform, |(k, _)| k);
+
+            let url = format!(
+                "https://github.com/sentrux/plugins/releases/download/{name}-v0.1.0/{name}-{platform_key}.tar.gz"
+            );
+            println!("Downloading {name} plugin for {platform_key}...");
+            println!("  {url}");
+
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let output = std::process::Command::new("curl")
+                .args(["-fsSL", &url, "-o"])
+                .arg(dir.join(format!("{name}.tar.gz")))
+                .status();
+
+            match output {
+                Ok(s) if s.success() => {
+                    let extract = std::process::Command::new("tar")
+                        .args(["xzf", &format!("{name}.tar.gz")])
+                        .current_dir(&dir)
+                        .status();
+                    let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
+                    match extract {
+                        Ok(s) if s.success() => {
+                            println!("Installed {name} to {}", plugin_dir.display());
+                        }
+                        _ => {
+                            eprintln!("Failed to extract plugin archive");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                _ => {
+                    let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
+                    eprintln!("Failed to download plugin '{name}'.");
+                    eprintln!("Check available plugins: https://github.com/sentrux/plugins/releases");
+                    std::process::exit(1);
+                }
+            }
+        }
+        PluginAction::Remove { name } => {
+            let dir = sentrux_core::analysis::plugin::plugins_dir()
+                .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
+            let plugin_dir = dir.join(&name);
+            if !plugin_dir.exists() {
+                eprintln!("Plugin '{}' not installed.", name);
+                std::process::exit(1);
+            }
+            std::fs::remove_dir_all(&plugin_dir).unwrap();
+            println!("Removed plugin '{}'", name);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GUI
+// ---------------------------------------------------------------------------
+
+fn run_gui(path: Option<String>) -> eframe::Result<()> {
+    let initial_path = path
+        .map(|p| {
+            std::path::Path::new(&p)
+                .canonicalize()
+                .map(|c| c.to_string_lossy().to_string())
+                .unwrap_or(p)
+        })
+        .filter(|p| std::path::Path::new(p).is_dir());
+
+    // Runtime backend fallback: try all backends first, then narrow down on failure.
+    // This handles every Linux GPU driver situation without compile-time guessing.
+    // User can always override with WGPU_BACKEND=vulkan|gl|dx12|metal env var.
+    let env_backends = eframe::wgpu::Backends::from_env();
+    let backend_attempts: Vec<eframe::wgpu::Backends> = if env_backends.is_some() {
+        // User explicitly chose — respect it, no fallback
+        vec![env_backends.unwrap()]
+    } else {
+        vec![
+            eframe::wgpu::Backends::PRIMARY | eframe::wgpu::Backends::GL, // try everything
+            eframe::wgpu::Backends::GL,                                    // GL-only fallback
+            eframe::wgpu::Backends::PRIMARY,                               // native-only fallback
+        ]
+    };
+
+    let title = if sentrux_core::license::current_tier() >= sentrux_core::license::Tier::Pro { "Sentrux Pro" } else { "sentrux" };
+
+    for (i, backends) in backend_attempts.iter().enumerate() {
+        eprintln!("[gpu] attempt {}/{}: backends {:?}", i + 1, backend_attempts.len(), backends);
+
+        let options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([1600.0, 1000.0])
+                .with_maximized(true)
+                .with_title(title),
+            renderer: eframe::Renderer::Wgpu,
+            wgpu_options: eframe::egui_wgpu::WgpuConfiguration {
+                wgpu_setup: eframe::egui_wgpu::WgpuSetup::CreateNew(eframe::egui_wgpu::WgpuSetupCreateNew {
+                    instance_descriptor: eframe::wgpu::InstanceDescriptor {
+                        backends: *backends,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let path_clone = initial_path.clone();
+        let result = eframe::run_native(
+            "Sentrux",
+            options,
+            Box::new(move |cc| Ok(Box::new(app::SentruxApp::new(cc, path_clone)))),
+        );
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                eprintln!("[gpu] backend {:?} failed: {}", backends, e);
+                if i + 1 == backend_attempts.len() {
+                    eprintln!("[gpu] all backends exhausted — try setting WGPU_BACKEND=gl or WGPU_BACKEND=vulkan");
+                    return Err(e);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 fn cli_scan_limits() -> analysis::scanner::common::ScanLimits {
     let s = core::settings::Settings::default();
     analysis::scanner::common::ScanLimits {
@@ -258,355 +698,4 @@ fn auto_install_plugins_if_needed() {
         }
     }
     eprintln!("\n\n  Installed {installed} language plugins.\n");
-}
-
-fn main() -> eframe::Result<()> {
-    // Auto-install standard plugins on first run
-    auto_install_plugins_if_needed();
-
-    // Non-blocking update check (once per day, background thread)
-    app::update_check::check_for_updates_async(env!("CARGO_PKG_VERSION"));
-
-    // --version: show version + edition (free or pro)
-    if std::env::args().any(|a| a == "--version" || a == "-V") {
-        let edition = if sentrux_core::license::current_tier() >= sentrux_core::license::Tier::Pro { "Pro" } else { "Free" };
-        println!("sentrux {} ({})", env!("CARGO_PKG_VERSION"), edition);
-        return Ok(());
-    }
-
-    if std::env::args().any(|a| a == "--mcp") {
-        app::mcp_server::run_mcp_server(None);
-        return Ok(());
-    }
-
-    // Plugin management commands
-    if std::env::args().any(|a| a == "plugin") {
-        let sub = std::env::args().skip_while(|a| a != "plugin").nth(1);
-        match sub.as_deref() {
-            Some("list") => {
-                let dir = sentrux_core::analysis::plugin::plugins_dir();
-                println!("Plugin directory: {}", dir.as_ref().map_or("(none)".into(), |d| d.display().to_string()));
-                let (loaded, errors) = sentrux_core::analysis::plugin::load_all_plugins();
-                if loaded.is_empty() && errors.is_empty() {
-                    println!("No plugins installed.");
-                    println!("\nInstall a plugin by placing it in ~/.sentrux/plugins/<name>/");
-                } else {
-                    for p in &loaded {
-                        println!("  {} v{} [{}] — {}", p.name, p.version, p.extensions.join(", "), p.display_name);
-                    }
-                    for e in &errors {
-                        println!("  (error) {} — {}", e.plugin_dir.display(), e.error);
-                    }
-                }
-                return Ok(());
-            }
-            Some("init") => {
-                let name = std::env::args().skip_while(|a| a != "init").nth(1)
-                    .unwrap_or_else(|| { eprintln!("Usage: sentrux plugin init <language-name>"); std::process::exit(1); });
-                let dir = sentrux_core::analysis::plugin::plugins_dir()
-                    .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
-                let plugin_dir = dir.join(&name);
-                if plugin_dir.exists() {
-                    eprintln!("Plugin directory already exists: {}", plugin_dir.display());
-                    std::process::exit(1);
-                }
-                std::fs::create_dir_all(plugin_dir.join("grammars")).unwrap();
-                std::fs::create_dir_all(plugin_dir.join("queries")).unwrap();
-                std::fs::create_dir_all(plugin_dir.join("tests")).unwrap();
-                std::fs::write(plugin_dir.join("plugin.toml"), format!(r#"[plugin]
-name = "{name}"
-display_name = "{name}"
-version = "0.1.0"
-extensions = ["TODO"]
-min_sentrux_version = "0.1.3"
-
-[plugin.metadata]
-author = ""
-description = ""
-
-[grammar]
-source = "https://github.com/TODO/tree-sitter-{name}"
-ref = "main"
-abi_version = 14
-
-[queries]
-capabilities = ["functions", "classes", "imports"]
-
-[checksums]
-"#)).unwrap();
-                std::fs::write(plugin_dir.join("queries").join("tags.scm"),
-                    ";; TODO: Write tree-sitter queries for this language\n;;\n;; Required captures:\n;;   @func.def / @func.name — function definitions\n;;   @class.def / @class.name — class definitions\n;;   @import.path — import statements\n;;   @call.name — function calls (optional)\n"
-                ).unwrap();
-                println!("Created plugin template at {}", plugin_dir.display());
-                println!("\nNext steps:");
-                println!("  1. Edit plugin.toml — set extensions, grammar source");
-                println!("  2. Build the grammar: tree-sitter generate && cc -shared -o grammars/{} src/parser.c",
-                    sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename());
-                println!("  3. Write queries/tags.scm");
-                println!("  4. Test: sentrux plugin validate {}", plugin_dir.display());
-                return Ok(());
-            }
-            Some("validate") => {
-                let path = std::env::args().skip_while(|a| a != "validate").nth(1)
-                    .unwrap_or_else(|| { eprintln!("Usage: sentrux plugin validate <plugin-dir>"); std::process::exit(1); });
-                let plugin_dir = std::path::Path::new(&path);
-                print!("Validating {}... ", plugin_dir.display());
-                match sentrux_core::analysis::plugin::manifest::PluginManifest::load(plugin_dir) {
-                    Ok(manifest) => {
-                        println!("plugin.toml OK");
-                        println!("  name: {}", manifest.plugin.name);
-                        println!("  version: {}", manifest.plugin.version);
-                        println!("  extensions: [{}]", manifest.plugin.extensions.join(", "));
-                        println!("  capabilities: [{}]", manifest.queries.capabilities.join(", "));
-                        let query_path = plugin_dir.join("queries").join("tags.scm");
-                        match std::fs::read_to_string(&query_path) {
-                            Ok(qs) => {
-                                match manifest.validate_query_captures(&qs) {
-                                    Ok(()) => println!("  queries/tags.scm: OK (captures valid)"),
-                                    Err(e) => println!("  queries/tags.scm: FAIL — {}", e),
-                                }
-                            }
-                            Err(e) => println!("  queries/tags.scm: MISSING — {}", e),
-                        }
-                        let gf = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
-                        let gp = plugin_dir.join("grammars").join(gf);
-                        if gp.exists() {
-                            println!("  grammars/{}: OK", gf);
-                        } else {
-                            println!("  grammars/{}: MISSING — build the grammar first", gf);
-                        }
-                    }
-                    Err(e) => {
-                        println!("FAIL — {}", e);
-                        std::process::exit(1);
-                    }
-                }
-                return Ok(());
-            }
-            Some("add-standard") => {
-                let standard = [
-                    "python", "javascript", "typescript", "rust", "go",
-                    "c", "cpp", "java", "ruby", "csharp", "php", "bash",
-                    "html", "css", "scss", "swift", "lua", "scala",
-                    "elixir", "haskell", "zig", "r", "ocaml",
-                ];
-                let dir = sentrux_core::analysis::plugin::plugins_dir()
-                    .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
-                std::fs::create_dir_all(&dir).unwrap();
-                let platform = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
-                let platform_key = platform.rsplit_once('.').map_or(platform, |(k, _)| k);
-                let mut installed = 0;
-                let mut skipped = 0;
-                for name in &standard {
-                    let plugin_dir = dir.join(name);
-                    if plugin_dir.exists() {
-                        skipped += 1;
-                        continue;
-                    }
-                    let url = format!(
-                        "https://github.com/sentrux/plugins/releases/download/{name}-v0.1.0/{name}-{platform_key}.tar.gz"
-                    );
-                    print!("  Installing {name}...");
-                    let _ = std::io::Write::flush(&mut std::io::stdout());
-                    let ok = std::process::Command::new("curl")
-                        .args(["-fsSL", &url, "-o"])
-                        .arg(dir.join(format!("{name}.tar.gz")))
-                        .status()
-                        .is_ok_and(|s| s.success());
-                    if ok {
-                        let extracted = std::process::Command::new("tar")
-                            .args(["xzf", &format!("{name}.tar.gz")])
-                            .current_dir(&dir)
-                            .status()
-                            .is_ok_and(|s| s.success());
-                        let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
-                        if extracted {
-                            println!(" ok");
-                            installed += 1;
-                        } else {
-                            println!(" failed (extract)");
-                        }
-                    } else {
-                        let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
-                        println!(" failed (download)");
-                    }
-                }
-                println!("\nInstalled {installed} languages ({skipped} already installed)");
-                return Ok(());
-            }
-            Some("add") => {
-                let name = std::env::args().skip_while(|a| a != "add").nth(1)
-                    .unwrap_or_else(|| { eprintln!("Usage: sentrux plugin add <name>"); std::process::exit(1); });
-                let dir = sentrux_core::analysis::plugin::plugins_dir()
-                    .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
-                let plugin_dir = dir.join(&name);
-                if plugin_dir.exists() {
-                    eprintln!("Plugin '{}' already installed at {}", name, plugin_dir.display());
-                    eprintln!("Remove it first: sentrux plugin remove {}", name);
-                    std::process::exit(1);
-                }
-
-                // Determine platform
-                let platform = sentrux_core::analysis::plugin::manifest::PluginManifest::grammar_filename();
-                let platform_key = platform.rsplit_once('.').map_or(platform, |(k, _)| k);
-
-                // Download from GitHub releases
-                let url = format!(
-                    "https://github.com/sentrux/plugins/releases/download/{name}-v0.1.0/{name}-{platform_key}.tar.gz"
-                );
-                println!("Downloading {name} plugin for {platform_key}...");
-                println!("  {url}");
-
-                // Ensure plugins directory exists before downloading
-                std::fs::create_dir_all(&dir).unwrap();
-
-                let output = std::process::Command::new("curl")
-                    .args(["-fsSL", &url, "-o"])
-                    .arg(dir.join(format!("{name}.tar.gz")))
-                    .status();
-
-                match output {
-                    Ok(s) if s.success() => {
-                        let extract = std::process::Command::new("tar")
-                            .args(["xzf", &format!("{name}.tar.gz")])
-                            .current_dir(&dir)
-                            .status();
-                        let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
-                        match extract {
-                            Ok(s) if s.success() => {
-                                println!("Installed {name} to {}", plugin_dir.display());
-                            }
-                            _ => {
-                                eprintln!("Failed to extract plugin archive");
-                                std::process::exit(1);
-                            }
-                        }
-                    }
-                    _ => {
-                        let _ = std::fs::remove_file(dir.join(format!("{name}.tar.gz")));
-                        eprintln!("Failed to download plugin '{name}'.");
-                        eprintln!("Check available plugins: https://github.com/sentrux/plugins/releases");
-                        std::process::exit(1);
-                    }
-                }
-                return Ok(());
-            }
-            Some("remove") => {
-                let name = std::env::args().skip_while(|a| a != "remove").nth(1)
-                    .unwrap_or_else(|| { eprintln!("Usage: sentrux plugin remove <name>"); std::process::exit(1); });
-                let dir = sentrux_core::analysis::plugin::plugins_dir()
-                    .unwrap_or_else(|| { eprintln!("Cannot determine home directory"); std::process::exit(1); });
-                let plugin_dir = dir.join(&name);
-                if !plugin_dir.exists() {
-                    eprintln!("Plugin '{}' not installed.", name);
-                    std::process::exit(1);
-                }
-                std::fs::remove_dir_all(&plugin_dir).unwrap();
-                println!("Removed plugin '{}'", name);
-                return Ok(());
-            }
-            _ => {
-                println!("Usage: sentrux plugin <add-standard|add|remove|list|init|validate>");
-                println!("  add-standard         — install all 23 standard languages");
-                println!("  add <name>          — install a single language plugin");
-                println!("  remove <name>        — remove an installed plugin");
-                println!("  list                — show installed plugins");
-                println!("  init <name>          — create a plugin template");
-                println!("  validate <dir>       — validate a plugin directory");
-                return Ok(());
-            }
-        }
-    }
-
-    if std::env::args().any(|a| a == "check") {
-        let path = std::env::args()
-            .skip_while(|a| a != "check")
-            .nth(1)
-            .unwrap_or_else(|| ".".to_string());
-        std::process::exit(run_check(&path));
-    }
-
-    if std::env::args().any(|a| a == "gate") {
-        let args: Vec<String> = std::env::args().collect();
-        std::process::exit(run_gate(&args));
-    }
-
-    // Extract positional path argument for TUI: `sentrux /path` or `sentrux scan /path`
-    let initial_path: Option<String> = {
-        let args: Vec<String> = std::env::args().skip(1).collect();
-        if args.first().map_or(false, |a| a == "scan") {
-            // `sentrux scan /path` — take path after "scan"
-            args.get(1).cloned()
-        } else {
-            // `sentrux /path` — first arg that doesn't start with '-'
-            args.first().filter(|a| !a.starts_with('-')).cloned()
-        }
-        .map(|p| {
-            // Resolve to absolute path
-            std::path::Path::new(&p)
-                .canonicalize()
-                .map(|c| c.to_string_lossy().to_string())
-                .unwrap_or(p)
-        })
-        .filter(|p| std::path::Path::new(p).is_dir())
-    };
-
-    // Runtime backend fallback: try all backends first, then narrow down on failure.
-    // This handles every Linux GPU driver situation without compile-time guessing.
-    // User can always override with WGPU_BACKEND=vulkan|gl|dx12|metal env var.
-    let env_backends = eframe::wgpu::Backends::from_env();
-    let backend_attempts: Vec<eframe::wgpu::Backends> = if env_backends.is_some() {
-        // User explicitly chose — respect it, no fallback
-        vec![env_backends.unwrap()]
-    } else {
-        vec![
-            eframe::wgpu::Backends::PRIMARY | eframe::wgpu::Backends::GL, // try everything
-            eframe::wgpu::Backends::GL,                                    // GL-only fallback
-            eframe::wgpu::Backends::PRIMARY,                               // native-only fallback
-        ]
-    };
-
-    let title = if sentrux_core::license::current_tier() >= sentrux_core::license::Tier::Pro { "Sentrux Pro" } else { "sentrux" };
-
-    for (i, backends) in backend_attempts.iter().enumerate() {
-        eprintln!("[gpu] attempt {}/{}: backends {:?}", i + 1, backend_attempts.len(), backends);
-
-        let options = eframe::NativeOptions {
-            viewport: egui::ViewportBuilder::default()
-                .with_inner_size([1600.0, 1000.0])
-                .with_maximized(true)
-                .with_title(title),
-            renderer: eframe::Renderer::Wgpu,
-            wgpu_options: eframe::egui_wgpu::WgpuConfiguration {
-                wgpu_setup: eframe::egui_wgpu::WgpuSetup::CreateNew(eframe::egui_wgpu::WgpuSetupCreateNew {
-                    instance_descriptor: eframe::wgpu::InstanceDescriptor {
-                        backends: *backends,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let path_clone = initial_path.clone();
-        let result = eframe::run_native(
-            "Sentrux",
-            options,
-            Box::new(move |cc| Ok(Box::new(app::SentruxApp::new(cc, path_clone)))),
-        );
-
-        match result {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                eprintln!("[gpu] backend {:?} failed: {}", backends, e);
-                if i + 1 == backend_attempts.len() {
-                    eprintln!("[gpu] all backends exhausted — try setting WGPU_BACKEND=gl or WGPU_BACKEND=vulkan");
-                    return Err(e);
-                }
-            }
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace fragile `std::env::args()` matching with clap's derive API (`Parser`/`Subcommand`)
- All subcommands (check, gate, scan, mcp, plugin) now have proper typed argument handling
- Adds `--help` and `--version` output for free via clap
- Plugin subcommands use nested `#[derive(Subcommand)]` instead of string matching
- Gate command gets proper `--save` flag and positional `path` arg instead of manual parsing

## Test plan
- [ ] `sentrux --help` shows all subcommands
- [ ] `sentrux check .` works as before
- [ ] `sentrux gate --save .` and `sentrux gate .` work as before
- [ ] `sentrux scan /path` opens GUI with path
- [ ] `sentrux plugin list` / `add` / `remove` / `init` / `validate` / `add-standard` all work
- [ ] `sentrux --mcp` hidden flag still works for backward compat
- [ ] `sentrux mcp` starts MCP server
- [ ] Bare `sentrux` (no args) opens GUI