### PR TITLE
Print WGPU_BACKEND hint on GPU init failure

### DIFF
--- a/sentrux-bin/src/main.rs
+++ b/sentrux-bin/src/main.rs
@@ -591,19 +591,27 @@ capabilities = ["functions", "classes", "imports"]
         };
 
         let path_clone = initial_path.clone();
-        let result = eframe::run_native(
-            "Sentrux",
-            options,
-            Box::new(move |cc| Ok(Box::new(app::SentruxApp::new(cc, path_clone)))),
-        );
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            eframe::run_native(
+                "Sentrux",
+                options,
+                Box::new(move |cc| Ok(Box::new(app::SentruxApp::new(cc, path_clone)))),
+            )
+        }));
 
         match result {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                eprintln!("[gpu] backend {:?} failed: {}", backends, e);
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(e)) => {
+                eprintln!("[gpu] backend {:?} failed: {e}", backends);
+                eprintln!("[gpu] hint: try setting WGPU_BACKEND=vulkan or WGPU_BACKEND=gl");
                 if i + 1 == backend_attempts.len() {
-                    eprintln!("[gpu] all backends exhausted — try setting WGPU_BACKEND=gl or WGPU_BACKEND=vulkan");
                     return Err(e);
+                }
+            }
+            Err(_) => {
+                eprintln!("[gpu] hint: try setting WGPU_BACKEND=vulkan or WGPU_BACKEND=gl");
+                if i + 1 == backend_attempts.len() {
+                    std::process::exit(1);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Wrap `eframe::run_native` in `catch_unwind` so we can print a hint after wgpu panics
- Print `[gpu] hint: try setting WGPU_BACKEND=vulkan or WGPU_BACKEND=gl` whenever a backend fails (error or panic)

## Context

On my machine, wgpu panics with `Invalid surface` during `Surface::configure` (missing DRI3/Vulkan support). The existing backend fallback loop doesn't help here because the panic kills the attempt, and retrying just hangs.

A proper fix (e.g. probing surface validity before configure, or running each attempt in a subprocess) would be too complex and ugly for what is a corner case. A simple hint pointing users to `WGPU_BACKEND` is enough — it's the standard escape hatch for this class of GPU driver issues.

## Test plan

- [ ] Verify hint appears after wgpu panic on affected system
- [ ] Verify normal startup on working GPU is unaffected