### PR TITLE
Fix Python metrics noise: Protocol abstractness, test instability, barrel fan-in

### DIFF
--- a/sentrux-core/src/metrics/arch/distance.rs
+++ b/sentrux-core/src/metrics/arch/distance.rs
@@ -115,6 +115,26 @@ fn is_abstract_kind(kind: Option<&str>) -> bool {
     matches!(kind, Some("interface") | Some("adt"))
 }
 
+/// Python base classes that indicate an abstract type.
+/// `typing.Protocol` (PEP 544) is the idiomatic way to define structural
+/// interfaces in modern Python — equivalent to Go interfaces or TypeScript
+/// structural types. `abc.ABC` / `ABCMeta` are the traditional approach.
+const PYTHON_ABSTRACT_BASES: &[&str] = &[
+    "Protocol", "ABC", "ABCMeta",
+];
+
+/// Check whether a class's base classes indicate it is abstract (Python).
+/// Covers `typing.Protocol`, `abc.ABC`, and `abc.ABCMeta`.
+fn has_abstract_base(bases: Option<&Vec<String>>) -> bool {
+    match bases {
+        Some(bs) => bs.iter().any(|b| {
+            let name = b.rsplit('.').next().unwrap_or(b);
+            PYTHON_ABSTRACT_BASES.contains(&name)
+        }),
+        None => false,
+    }
+}
+
 /// Count abstract and total types in a single file node's class list.
 fn count_file_types(
     node: &crate::core::types::FileNode,
@@ -131,7 +151,7 @@ fn count_file_types(
     let mut abstract_count = 0usize;
     for cls in classes {
         total_count += 1;
-        if is_abstract_kind(cls.k.as_deref()) {
+        if is_abstract_kind(cls.k.as_deref()) || has_abstract_base(cls.b.as_ref()) {
             abstract_count += 1;
         }
     }

--- a/sentrux-core/src/metrics/arch/mod.rs
+++ b/sentrux-core/src/metrics/arch/mod.rs
@@ -362,7 +362,13 @@ fn find_max_non_foundation_blast(
     for (path, &blast) in blast_radius {
         let module = crate::core::path_utils::module_of(path).to_string();
         let ca = file_fan_in.get(path.as_str()).copied().unwrap_or(0);
-        let is_foundation = is_foundation_module(&module) || ca >= MIN_FILE_FAN_IN_FOUNDATION;
+        // Package-index files (__init__.py, index.js, mod.rs, etc.) are barrel
+        // re-exporters — their high blast radius reflects re-exports, not genuine
+        // change risk. Treat them as foundation regardless of instability.
+        let is_barrel = super::is_package_index_file(path);
+        let is_foundation = is_barrel
+            || is_foundation_module(&module)
+            || ca >= MIN_FILE_FAN_IN_FOUNDATION;
         if !is_foundation && blast > max_non_foundation {
             max_non_foundation = blast;
         }

--- a/sentrux-core/src/metrics/mod.rs
+++ b/sentrux-core/src/metrics/mod.rs
@@ -48,6 +48,14 @@ use crate::core::snapshot::Snapshot;
 use crate::core::types::FileNode;
 use std::collections::{HashMap, HashSet};
 
+/// Check if a file path ends with a known package-index filename.
+/// Package-index files (__init__.py, mod.rs, index.js, etc.) act as barrel
+/// re-exporters whose fan-in reflects re-exports, not genuine coupling.
+pub(crate) fn is_package_index_file(path: &str) -> bool {
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    crate::analysis::resolver::helpers::PACKAGE_INDEX_FILES.contains(&filename)
+}
+
 /// Compute per-file fan-out and fan-in counts from import edges.
 /// Excludes mod declarations (Rust `mod foo;`) which are structural, not coupling.
 fn compute_fan_maps(import_edges: &[ImportEdge]) -> (HashMap<String, usize>, HashMap<String, usize>) {
@@ -85,11 +93,16 @@ fn detect_god_files(
 
 /// Detect hotspot files: high fan-in files that are also unstable (I >= 0.15).
 /// Stable foundations (high fan-in + low fan-out) are excluded per Martin's SDP.
+/// Package-index files (__init__.py, index.js, mod.rs, etc.) are excluded because
+/// their fan-in reflects barrel re-exports, not genuine coupling hotspots.
 fn detect_hotspot_files(fan_in: &HashMap<String, usize>, fan_out: &HashMap<String, usize>) -> Vec<FileMetric> {
     let mut v: Vec<FileMetric> = fan_in
         .iter()
         .filter(|(path, &count)| {
             if count <= FAN_IN_THRESHOLD { return false; }
+            // Exclude package-index / barrel files — their high fan-in is an
+            // artifact of re-exporting, not a design flaw.
+            if is_package_index_file(path) { return false; }
             // Exclude stable foundations (I < 0.15): high fan-in + low fan-out
             // is GOOD architecture (Martin's SDP). Only flag unstable hotspots.
             let fo = *fan_out.get(path.as_str()).unwrap_or(&0);
@@ -115,6 +128,7 @@ fn compute_instability(
     }
     let mut v: Vec<InstabilityMetric> = all_files
         .iter()
+        .filter(|&&path| !testgap::is_test_file(path))
         .map(|&path| {
             let ce = *fan_out.get(path).unwrap_or(&0);
             let ca = *fan_in.get(path).unwrap_or(&0);


### PR DESCRIPTION
## Summary

Fixes three sources of misleading metrics when analyzing Python projects:

- **Protocol abstractness**: Recognize `typing.Protocol`, `abc.ABC`, and `ABCMeta` as abstract types when computing Abstractness (A), preventing false "Zone of Pain" flags on packages with well-defined interfaces
- **Test file noise**: Exclude test files from instability computation — I=1.0 is inherent to tests, not a design flaw
- **Barrel file inflation**: Exclude package-index files (`__init__.py`, `index.js`, `mod.rs`) from hotspot detection and treat them as foundation in blast radius grading, since their high fan-in reflects re-exports, not genuine coupling

Closes #10

## Test plan

- [x] All 270 existing tests pass
- [x] No new clippy warnings
- [ ] Verify on a real Python project that Protocol classes increase package Abstractness
- [ ] Verify `__init__.py` no longer appears as top hotspot
- [ ] Verify test files no longer appear in UNSTABLE list