### PR TITLE
feat: add Elixir import resolution for cohesion metrics

### DIFF
--- a/sentrux-core/src/analysis/parser/imports.rs
+++ b/sentrux-core/src/analysis/parser/imports.rs
@@ -47,6 +47,7 @@ pub(crate) fn extract_import_modules(text: &str, lang: &str) -> Vec<String> {
         "html" => lang_extractors::extract_html(text),
         "css" | "scss" | "sass" => lang_extractors::extract_css(text),
         "scala" | "swift" | "kotlin" => lang_extractors::extract_jvm_like(text),
+        "elixir" => lang_extractors::extract_elixir(text),
         _ => lang_extractors::extract_fallback(text),
     };
 

--- a/sentrux-core/src/analysis/parser/lang_extractors.rs
+++ b/sentrux-core/src/analysis/parser/lang_extractors.rs
@@ -220,6 +220,102 @@ pub(super) fn extract_jvm_like(text: &str) -> Vec<String> {
     if s.is_empty() { vec![] } else { vec![s] }
 }
 
+/// Convert a PascalCase string to snake_case.
+/// Examples: "GenServer" → "gen_server", "HTTPClient" → "http_client", "IO" → "io"
+fn pascal_to_snake(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 4);
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                let prev = chars[i - 1];
+                if prev.is_lowercase() || prev.is_ascii_digit()
+                    || (prev.is_uppercase()
+                        && chars.get(i + 1).is_some_and(|ch| ch.is_lowercase()))
+                {
+                    result.push('_');
+                }
+            }
+            result.push(c.to_lowercase().next().unwrap());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Convert an Elixir module name to a file-system path.
+/// "Collect.Listing" → "collect/listing", "GenServer" → "gen_server"
+fn elixir_module_to_path(module: &str) -> String {
+    module
+        .split('.')
+        .map(pascal_to_snake)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Expand Elixir multi-alias syntax: "Collect.{Listing, Offer}" → ["collect/listing", "collect/offer"]
+fn expand_elixir_multi_alias(text: &str) -> Vec<String> {
+    let brace_start = match text.find('{') {
+        Some(i) => i,
+        None => return vec![],
+    };
+    let brace_end = match text.find('}') {
+        Some(i) => i,
+        None => return vec![],
+    };
+    // Prefix is everything before ".{" — strip the trailing dot
+    let prefix = text[..brace_start].trim_end_matches('.');
+    let items = &text[brace_start + 1..brace_end];
+    items
+        .split(',')
+        .map(|item| {
+            let name = item.trim();
+            if name.is_empty() {
+                String::new()
+            } else {
+                elixir_module_to_path(&format!("{}.{}", prefix, name))
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+pub(super) fn extract_elixir(text: &str) -> Vec<String> {
+    let trimmed = text.trim();
+    // Strip keyword prefix
+    let rest = if let Some(r) = trimmed.strip_prefix("alias ") { r }
+        else if let Some(r) = trimmed.strip_prefix("import ") { r }
+        else if let Some(r) = trimmed.strip_prefix("use ") { r }
+        else if let Some(r) = trimmed.strip_prefix("require ") { r }
+        else { return vec![] };
+
+    let rest = rest.trim_start();
+
+    // Stop at first newline (multi-line do blocks)
+    let rest = rest.split('\n').next().unwrap_or(rest);
+
+    // Handle multi-alias: alias Collect.{Listing, Offer}
+    if rest.contains('{') {
+        return expand_elixir_multi_alias(rest);
+    }
+
+    // Extract module name: first token (PascalCase segments separated by dots)
+    // Stop at comma (options), whitespace after module, or "do"
+    let module = rest
+        .split(|c: char| c == ',' || c == ' ' || c == '\t')
+        .next()
+        .unwrap_or("")
+        .trim();
+
+    if module.is_empty() || !module.starts_with(|c: char| c.is_uppercase()) {
+        return vec![];
+    }
+
+    let path = elixir_module_to_path(module);
+    if path.is_empty() { vec![] } else { vec![path] }
+}
+
 pub(super) fn extract_fallback(text: &str) -> Vec<String> {
     // Search for standalone "from" keyword (word boundary), not substring inside
     // identifiers like "transform", "perform", "platform".

--- a/sentrux-core/src/queries/elixir/tags.scm
+++ b/sentrux-core/src/queries/elixir/tags.scm
@@ -36,3 +36,10 @@
 (binary_operator
   operator: "|>"
   right: (identifier) @name) @reference.call
+
+; ---- Import appendix (custom) ----
+; alias/import/use/require — capture the whole call as @import
+; so extract_elixir() can parse the keyword + module name from text.
+(call
+  target: (identifier) @_import_kw
+  (#any-of? @_import_kw "alias" "import" "use" "require")) @import


### PR DESCRIPTION
## Summary

- Elixir projects had **zero import edges** because the tree-sitter query had no `@import` captures (alias/import/use/require were in the ignore block) and there was no language-specific extractor — Elixir fell through to `extract_fallback` which can't parse Elixir's module syntax
- Without import edges, **cohesion, coupling, and entropy were unmeasurable** for Elixir codebases
- This PR adds full Elixir import support across three files:
  - `queries/elixir/tags.scm` — capture `alias`/`import`/`use`/`require` calls as `@import`
  - `lang_extractors.rs` — `extract_elixir()` with PascalCase→snake_case module-to-path conversion (`Collect.Listing` → `collect/listing`) and multi-alias expansion (`Collect.{Listing, Offer}`)
  - `imports.rs` — wire `"elixir"` into the language dispatch

## Validation

Tested on a 7,037-file Elixir umbrella project:

| Metric | Before | After |
|--------|--------|-------|
| Import edges | 0 | 10,651 |
| Cohesion | unmeasurable (None) | **B** (0.45) |
| Coupling | 0.00 (no edges) | **C** (0.47) |
| Entropy | 0.00 | **C** (0.79) |

All 261 existing tests pass. No changes to non-Elixir behavior.

## Test plan

- [x] `cargo build --release` — clean compile
- [x] `cargo test` — 261 passed, 0 failed
- [x] MCP `scan` + `health` on real Elixir project — cohesion now visible
- [ ] Add unit tests for `pascal_to_snake`, `elixir_module_to_path`, `extract_elixir`
- [ ] Add parser integration test for Elixir import extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)