### PR TITLE
fix: resolve Go single-segment package imports

### DIFF
--- a/sentrux-core/src/analysis/graph/tests2.rs
+++ b/sentrux-core/src/analysis/graph/tests2.rs
@@ -513,4 +513,45 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    #[test]
+    fn go_flat_package_single_segment_resolves() {
+        // Regression: Go project with a single subpackage at the root level.
+        // `import "github.com/user/repo/parser"` strips to "parser" — a single
+        // segment with many candidates (every .go file in parser/). The suffix
+        // index len()==1 guard previously blocked resolution because "parser"
+        // matched multiple files.
+        let tmp = std::env::temp_dir().join("sentrux_test_go_flat_pkg");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("parser")).unwrap();
+        std::fs::write(tmp.join("go.mod"),
+            "module github.com/user/myapp\n\ngo 1.21\n").unwrap();
+
+        let files = vec![
+            make_file("main.go", "main.go", "go",
+                Some(StructuralAnalysis {
+                    functions: None, cls: None, co: None, tags: None, comment_lines: None,
+                    imp: Some(vec![
+                        "github.com/user/myapp/parser".to_string(),
+                    ]),
+                }),
+            ),
+            make_file("session.go", "parser/session.go", "go", None),
+            make_file("entry.go", "parser/entry.go", "go", None),
+            make_file("chunk.go", "parser/chunk.go", "go", None),
+        ];
+
+        let refs: Vec<&FileNode> = files.iter().collect();
+        let gr = build_graphs(&refs, Some(&tmp), 5);
+
+        let main_edges: Vec<&ImportEdge> = gr.import_edges.iter()
+            .filter(|e| e.from_file == "main.go").collect();
+
+        assert!(!main_edges.is_empty(),
+            "expected at least 1 import edge from main.go to parser/, got none");
+        assert!(main_edges.iter().all(|e| e.to_file.starts_with("parser/")),
+            "all edges should target parser/, got {:?}", main_edges);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/sentrux-core/src/analysis/resolver/helpers.rs
+++ b/sentrux-core/src/analysis/resolver/helpers.rs
@@ -80,9 +80,22 @@ pub(super) fn try_suffix_resolve(
     // so we jump straight to the local path instead of progressive stripping.
     if !env.suffix_index.module_prefixes.is_empty() {
         if let Some(local_path) = strip_module_prefix(specifier, &env.suffix_index.module_prefixes) {
-            // Try the module-stripped path through the suffix index
+            // Module-prefix-stripped paths have high confidence of being local
+            // imports. Use pick_closest for disambiguation even with multiple
+            // candidates — this is needed for directory_is_package languages
+            // (Go) where a package import like "parser" maps to every .go file
+            // in that directory.
             if let Some(result) = try_suffix_resolve_inner(&local_path, env, file_dir_str, file_dir) {
                 return Some(result);
+            }
+            // Fallback: direct suffix index lookup with pick_closest.
+            // try_suffix_resolve_inner's len()==1 guard may have rejected a
+            // multi-candidate single-segment match (e.g. "parser" -> 37 files).
+            // Since we know this came from a module prefix, it's safe to pick.
+            if let Some(candidates) = env.suffix_index.index.get(local_path.as_str()) {
+                if !candidates.is_empty() {
+                    return Some(pick_closest(candidates, file_dir_str).to_string());
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Go imports that strip to a single path segment (e.g. `"github.com/user/repo/parser"` -> `"parser"`) were silently dropped when the suffix index found multiple candidates
- This affected all Go projects where a subpackage contains more than one `.go` file — the common case
- The result: 0 import edges, Architecture: A reported vacuously (absence of data, not quality)

## Root cause

`try_suffix_resolve_inner` has a `candidates.len() == 1` guard for single-segment suffix lookups to prevent false matches on ambiguous bare specifiers (e.g. Rust's `std::io` matching a project's `src/io.rs`). Module-prefix-stripped paths bypass this guard in the multi-segment case (the `while remainder.contains('/')` loop uses `pick_closest` regardless of candidate count) but not the single-segment case.

## Fix

After `try_suffix_resolve_inner` rejects a multi-candidate single-segment match, check whether the specifier was module-prefix-stripped. If so, fall back to `pick_closest` — the same disambiguation strategy already used for multi-segment paths. The len()==1 guard is preserved for non-module-prefix paths.

## Before / After (real Go project, ~5k lines)

| Metric | Before | After |
|--------|--------|-------|
| Import edges | 0 | 29 |
| Call edges | 0 | 9 |
| Structure grade | D | C |
| Distance from Main Sequence | 0.50 | 0.09 |

197 specs correctly remain unresolved (stdlib + third-party imports).

## Test plan

- [x] Added `go_flat_package_single_segment_resolves` regression test
- [x] All 292 existing tests pass (including `rust_std_io_no_false_match_to_project_io` which validates the ambiguity guard for non-module-prefix paths)
- [x] Verified against a real Go project ([tail-claude](https://github.com/kylesnowschwartz/tail-claude))