### PR TITLE
Fix opensource compilation: remove sentrux-pro path dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,7 +3385,6 @@ dependencies = [
  "eframe",
  "egui",
  "sentrux-core",
- "sentrux-pro",
 ]
 
 [[package]]
@@ -3412,15 +3411,6 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tree-sitter",
-]
-
-[[package]]
-name = "sentrux-pro"
-version = "0.5.4"
-dependencies = [
- "dirs",
- "sentrux-core",
- "serde_json",
 ]
 
 [[package]]

--- a/sentrux-bin/Cargo.toml
+++ b/sentrux-bin/Cargo.toml
@@ -23,8 +23,4 @@ egui = { workspace = true }
 
 [features]
 default = []
-pro = ["sentrux-core/pro", "dep:sentrux-pro"]
-
-[dependencies.sentrux-pro]
-path = "../../sentrux-pro"
-optional = true
+pro = ["sentrux-core/pro"]

--- a/sentrux-bin/src/main_impl.rs
+++ b/sentrux-bin/src/main_impl.rs
@@ -155,9 +155,7 @@ enum PluginAction {
 // ---------------------------------------------------------------------------
 
 pub fn run() -> eframe::Result<()> {
-    // Step 0: Initialize Pro tier if compiled with pro feature
-    #[cfg(feature = "pro")]
-    sentrux_pro::init();
+    // Pro tier is set externally by the sentrux-pro crate before calling run().
 
     // Step 1: Download missing grammar binaries (may overwrite configs with old versions)
     ensure_grammars_installed();


### PR DESCRIPTION
## Problem

The `sentrux-bin` crate has an optional path dependency on `sentrux-pro` at `../../sentrux-pro`:

```toml
[dependencies.sentrux-pro]
path = "../../sentrux-pro"
optional = true
```

This path doesn't exist for opensource users. Even though the dependency is optional, Cargo still resolves it during dependency resolution, producing a **cyclic package dependency** error:

```
error: cyclic package dependency: package `sentrux v0.5.5` depends on itself. Cycle:
package `sentrux v0.5.5`
    ... which satisfies path dependency `sentrux-bin` of package `sentrux-pro v0.5.4`
    ... which satisfies path dependency `sentrux-pro` of package `sentrux v0.5.5`
```

This means `cargo build` / `cargo check` fails on a clean clone of the repo.

CI currently works around this by creating a fake stub crate at `../sentrux-pro/` (`ci.yml:41-62`), but anyone building from source outside CI hits this error immediately.

## Fix

- Remove the `[dependencies.sentrux-pro]` path dependency and `dep:sentrux-pro` from the `pro` feature
- Keep the `pro` feature flag itself — it still activates `sentrux-core/pro`
- Remove the `sentrux_pro::init()` call (the pro crate can call init externally before `run()`)
- Clean up `Cargo.lock`

The sentrux-pro crate can still enable the `pro` feature by depending on sentrux-bin with `features = ["pro"]`, so the optional pro compilation path is preserved — just inverted from pull to push.

## Bonus

After this change, the "Create Pro stub" step in `ci.yml` (lines 41-62) can be removed — it's no longer needed.