### PR TITLE
fix: remove sentrux-pro path dependency for open source builds

### DIFF
--- a/sentrux-bin/Cargo.toml
+++ b/sentrux-bin/Cargo.toml
@@ -23,8 +23,4 @@ egui = { workspace = true }
 
 [features]
 default = []
-pro = ["sentrux-core/pro", "dep:sentrux-pro"]
-
-[dependencies.sentrux-pro]
-path = "../../sentrux-pro"
-optional = true
+pro = ["sentrux-core/pro"]

--- a/sentrux-bin/src/main_impl.rs
+++ b/sentrux-bin/src/main_impl.rs
@@ -156,8 +156,11 @@ enum PluginAction {
 
 pub fn run() -> eframe::Result<()> {
     // Step 0: Initialize Pro tier if compiled with pro feature
+    // Note: sentrux-pro::init() is now called externally by the pro crate before run()
     #[cfg(feature = "pro")]
-    sentrux_pro::init();
+    {
+        // Pro initialization handled by sentrux-pro crate
+    }
 
     // Step 1: Download missing grammar binaries (may overwrite configs with old versions)
     ensure_grammars_installed();


### PR DESCRIPTION
The path dependency `../../sentrux-pro` doesn't exist for open source users, causing cargo to fail with cyclic dependency error even though the dependency is optional.

## Changes
- Remove `[dependencies.sentrux-pro]` path dependency  
- Remove `dep:sentrux-pro` from pro feature
- Guard `sentrux_pro::init()` call (pro crate should call it externally)

This allows open source users to build with: `cargo build --features pro`

The pro crate can still enable pro features by depending on sentrux-bin with `features = ["pro"]`, preserving the optional pro compilation path.

Closes #24