### PR TITLE
fix(release): gate release and formula update on all builds succeeding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,6 @@ jobs:
 
   release:
     needs: build
-    if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
The `release` job used `if: always() && !cancelled()`, causing the GitHub release and Homebrew formula update to proceed even when build matrix jobs failed. This allowed the formula to be bumped to a version with missing binaries (as happened in v0.5.6).

Removing the condition restores the default `needs` behaviour: the release only publishes when all platform builds succeed.