### PR TITLE
fix: filter git-tracked dependency dirs from scan results

### DIFF
--- a/sentrux-core/src/analysis/scanner/common.rs
+++ b/sentrux-core/src/analysis/scanner/common.rs
@@ -64,6 +64,11 @@ pub(crate) fn detect_lang(path: &Path) -> String {
 const GLOBAL_IGNORED_DIRS: &[&str] = &[
     ".git", ".DS_Store", ".claude", ".cognitive", ".beemem",
     "lib64", "include",
+    // Common dependency/build dirs — ensures filtering even when plugins
+    // haven't loaded yet (LazyLock initialization race).
+    "node_modules", "vendor", ".next", "dist", "build", "target",
+    "__pycache__", ".pytest_cache", ".venv", "venv",
+    "DerivedData", ".build", ".swiftpm",
 ];
 
 /// Merged ignored dirs: global + all plugins. Cached at first access.

--- a/sentrux-core/src/analysis/scanner/mod.rs
+++ b/sentrux-core/src/analysis/scanner/mod.rs
@@ -59,6 +59,18 @@ fn process_walk_entry(
         return ignore::WalkState::Continue;
     }
     let path = entry.path().to_path_buf();
+    // Reject files inside globally ignored dirs (e.g. node_modules) even when
+    // git-tracked. The walker's filter_entry doesn't reliably prevent descent
+    // into tracked-but-ignored directories in parallel mode.
+    if path.components().any(|c| {
+        if let std::path::Component::Normal(s) = c {
+            s.to_str().is_some_and(|name| should_ignore_dir(name))
+        } else {
+            false
+        }
+    }) {
+        return ignore::WalkState::Continue;
+    }
     if should_ignore_file(&path) {
         return ignore::WalkState::Continue;
     }
@@ -121,6 +133,14 @@ fn collect_paths_git(root: &Path, file_size_limit: u64) -> Option<Vec<CollectedF
         .take(MAX_FILES)
         .filter_map(|rel| {
             let abs = root.join(rel);
+            // Skip files inside globally ignored dirs (e.g. node_modules)
+            // even when git-tracked — some repos commit their dependencies.
+            if std::path::Path::new(rel).components().any(|c| {
+                matches!(c, std::path::Component::Normal(s) if s.to_str().is_some_and(|n| should_ignore_dir(n)))
+            }) {
+                ignored_ext += 1;
+                return None;
+            }
             if should_ignore_file(&abs) {
                 ignored_ext += 1;
                 return None;
@@ -183,6 +203,14 @@ fn collect_paths_walk(root: &Path, file_size_limit: u64) -> Vec<CollectedFile> {
                     return ignore::WalkState::Quit;
                 }
                 if let Ok(entry) = result {
+                    // Skip ignored dirs even when git-tracked (e.g. committed node_modules).
+                    // filter_entry doesn't apply in parallel mode, so check here.
+                    if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                        let name = entry.file_name().to_string_lossy();
+                        if should_ignore_dir(&name) {
+                            return ignore::WalkState::Skip;
+                        }
+                    }
                     return process_walk_entry(&entry, file_size_limit, &count, &tx);
                 }
                 ignore::WalkState::Continue


### PR DESCRIPTION
The scanner's `collect_paths_git` function trusts `git ls-files` output without checking for globally ignored directories. When a repo commits dependency dirs (e.g. node_modules), they pollute scan results with thousands of irrelevant files, tanking the quality signal.

Three changes:
- Add common dependency/build dirs (node_modules, vendor, __pycache__, DerivedData, etc.) to GLOBAL_IGNORED_DIRS so they're filtered even before plugins load (fixes LazyLock initialization race)
- Filter files by path components in collect_paths_git (the primary scan path for git repos)
- Apply same filtering in process_walk_entry and collect_paths_walk (filesystem walker fallback for non-git dirs)

Tested: cmux repo drops from 5927 files / score 3955 to 1000 files / score 7097 — the committed node_modules was the sole cause of 4 false cycle detections and a ~45% score penalty.