### PR TITLE
feat: ignore .jj directory in default ignore list

### DIFF
--- a/sentrux-core/src/analysis/scanner/common.rs
+++ b/sentrux-core/src/analysis/scanner/common.rs
@@ -62,7 +62,7 @@ pub(crate) fn detect_lang(path: &Path) -> String {
 /// Global ignored dirs (OS/tool artifacts, not language-specific).
 /// Language-specific ignored dirs come from plugin.toml [semantics.project].
 const GLOBAL_IGNORED_DIRS: &[&str] = &[
-    ".git", ".DS_Store", ".claude", ".cognitive", ".beemem",
+    ".git", ".jj", ".DS_Store", ".claude", ".cognitive", ".beemem",
     "lib64", "include",
 ];
 


### PR DESCRIPTION
## Why

Sentrux maintains a hardcoded list of directories to ignore during scans (`.git`, `.DS_Store`, `.claude`, etc.). This list exists because those paths are tool/OS internals — never user code.

[Jujutsu (jj)](https://github.com/jj-vcs/jj) is a modern, Git-compatible version control system that is gaining traction as a superset on top of everyday Git workflows. It stores its internal state in a `.jj/` directory at the repo root — exactly the same role `.git/` plays for plain Git repos.

Unlike `.git/`, the `.jj/` directory cannot be added to `.gitignore`. The reason: `.gitignore` is processed by Git, and `.jj/` is not a Git-tracked path from Git's perspective — the same reason `.git/` shouldn't be added to the `.gitignore` file. There is no escaping this at the project level.

The screenshot below shows what happens in a jj-managed repo today: Sentrux picks up hundreds of `.jj/` internal temp files (lock files, working copy snapshots, export artifacts) and surfaces them in the activity feed and scan results as if they were source files.

<img width="726" height="494" alt="sentrux-jj" src="https://github.com/user-attachments/assets/2529f327-a948-4f2c-8396-97164d5e88b3" /><br />

> The Q:5783 token count and the `.jj/working_copy/` paths in the activity panel are jj internals — not user code.

## What

Added `.jj` to `GLOBAL_IGNORED_DIRS` in `sentrux-core/src/analysis/scanner/common.rs`, alongside the existing `.git` entry.

```rust
// before
".git", ".DS_Store", ".claude", ".cognitive", ".beemem",

// after
".git", ".jj", ".DS_Store", ".claude", ".cognitive", ".beemem",
```

One line change. No new logic, no configuration surface, no behaviour change for non-jj repos.

## Impact

- jj repos: `.jj/` fully excluded from scans, dependency graphs, token counts, and activity feeds
- git repos: no change
- repos using both (`jj` colocated mode, which maintains both `.git/` and `.jj/`): both excluded
