### PR TITLE
[codex] Include untracked files in scans on request

### DIFF
--- a/sentrux-bin/src/main_impl.rs
+++ b/sentrux-bin/src/main_impl.rs
@@ -71,6 +71,10 @@ enum Command {
         /// Directory to check
         #[arg(default_value = ".")]
         path: String,
+
+        /// Include untracked, non-ignored Git worktree files in the scan
+        #[arg(long)]
+        include_untracked: bool,
     },
 
     /// Structural regression gate — compare against a saved baseline
@@ -199,8 +203,8 @@ pub fn run() -> eframe::Result<()> {
     }
 
     match cli.command {
-        Some(Command::Check { path }) => {
-            std::process::exit(run_check(&path));
+        Some(Command::Check { path, include_untracked }) => {
+            std::process::exit(run_check(&path, include_untracked));
         }
         Some(Command::Gate { save, path }) => {
             std::process::exit(run_gate(&path, save));
@@ -422,7 +426,7 @@ fn run_analytics(action: Option<AnalyticsAction>) {
 // ---------------------------------------------------------------------------
 
 /// Run architectural rules check from CLI. Returns exit code.
-fn run_check(path: &str) -> i32 {
+fn run_check(path: &str, include_untracked: bool) -> i32 {
     let root = std::path::Path::new(path);
     if !root.is_dir() {
         eprintln!("Error: not a directory: {path}");
@@ -438,11 +442,16 @@ fn run_check(path: &str) -> i32 {
         }
     };
 
-    eprintln!("Scanning {path}...");
-    let result = match analysis::scanner::scan_directory(
+    if include_untracked {
+        eprintln!("Scanning {path} including untracked files...");
+    } else {
+        eprintln!("Scanning {path}...");
+    }
+    let result = match analysis::scanner::scan_directory_with_options(
         path, None, None,
         &cli_scan_limits(),
         None,
+        analysis::scanner::ScanOptions { include_untracked },
     ) {
         Ok(r) => r,
         Err(e) => {

--- a/sentrux-core/src/analysis/scanner/mod.rs
+++ b/sentrux-core/src/analysis/scanner/mod.rs
@@ -18,7 +18,7 @@ use crate::core::snapshot::{ScanProgress, Snapshot};
 use crate::core::types::FileNode;
 use ignore::WalkBuilder;
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -29,6 +29,13 @@ use std::time::UNIX_EPOCH;
 struct CollectedFile {
     path: PathBuf,
     mtime: f64,
+}
+
+/// Optional scan behavior for callers that need to widen the default project file set.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ScanOptions {
+    /// Include untracked, non-ignored Git worktree files in addition to tracked files.
+    pub include_untracked: bool,
 }
 
 /// Extract mtime as f64 seconds since UNIX_EPOCH from file metadata.
@@ -83,11 +90,11 @@ fn process_walk_entry(
 /// First-principles reasoning: the user's git index is the single source of truth for
 /// what constitutes "their code." It handles .gitignore, monorepos, workspaces, and
 /// any project structure without heuristics or hardcoded ignore lists.
-fn collect_paths(root: &Path, file_size_limit: u64) -> Vec<CollectedFile> {
+fn collect_paths(root: &Path, file_size_limit: u64, options: ScanOptions) -> Vec<CollectedFile> {
     // Try git ls-files first — the universal correct approach
-    if let Some(files) = collect_paths_git(root, file_size_limit) {
+    if let Some(files) = collect_paths_git(root, file_size_limit, options) {
         if !files.is_empty() {
-            crate::debug_log!("[scan] using git ls-files ({} tracked files)", files.len());
+            crate::debug_log!("[scan] using git ls-files ({} files)", files.len());
             return files;
         }
     }
@@ -99,25 +106,33 @@ fn collect_paths(root: &Path, file_size_limit: u64) -> Vec<CollectedFile> {
 /// Collect files via `git ls-files` — returns None if not a git repo or git fails.
 /// This is the primary path: git already knows every tracked file, respects .gitignore,
 /// handles monorepos/workspaces, and requires zero heuristic filtering.
-fn collect_paths_git(root: &Path, file_size_limit: u64) -> Option<Vec<CollectedFile>> {
-    let output = std::process::Command::new("git")
-        .args(["ls-files", "-z"])  // null-delimited for safe path handling
-        .current_dir(root)
-        .output()
-        .ok()?;
+fn collect_paths_git(
+    root: &Path,
+    file_size_limit: u64,
+    options: ScanOptions,
+) -> Option<Vec<CollectedFile>> {
+    let tracked = git_ls_files(root, &["ls-files", "-z"])?;
+    let untracked = if options.include_untracked {
+        git_ls_files(root, &["ls-files", "-z", "--others", "--exclude-standard"])
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
-    if !output.status.success() {
-        return None; // not a git repo or git not available
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let total_git = stdout.split('\0').filter(|s| !s.is_empty()).count();
+    let total_tracked = tracked.len();
+    let total_untracked = untracked.len();
+    let mut seen = HashSet::new();
+    let entries: Vec<String> = tracked
+        .into_iter()
+        .chain(untracked)
+        .filter(|rel| seen.insert(rel.clone()))
+        .collect();
+    let total_git = entries.len();
     let mut ignored_ext = 0u32;
     let mut meta_fail = 0u32;
     let mut too_big = 0u32;
-    let files: Vec<CollectedFile> = stdout
-        .split('\0')
-        .filter(|s| !s.is_empty())
+    let files: Vec<CollectedFile> = entries
+        .iter()
         .take(MAX_FILES)
         .filter_map(|rel| {
             let abs = root.join(rel);
@@ -139,13 +154,32 @@ fn collect_paths_git(root: &Path, file_size_limit: u64) -> Option<Vec<CollectedF
         .collect();
 
     let dropped = total_git - files.len();
-    if dropped > 0 {
+    if dropped > 0 || options.include_untracked {
         eprintln!(
-            "[scan] git ls-files: {} total, {} kept, {} dropped (ext:{}, meta:{}, big:{})",
-            total_git, files.len(), dropped, ignored_ext, meta_fail, too_big
+            "[scan] git ls-files: {} total ({} tracked, {} untracked), {} kept, {} dropped (ext:{}, meta:{}, big:{})",
+            total_git, total_tracked, total_untracked, files.len(), dropped, ignored_ext, meta_fail, too_big
         );
     }
     Some(files)
+}
+
+fn git_ls_files(root: &Path, args: &[&str]) -> Option<Vec<String>> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None; // not a git repo or git not available
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Some(stdout
+        .split('\0')
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect())
 }
 
 /// Fallback: filesystem walk for non-git directories.
@@ -259,12 +293,13 @@ fn walk_and_scan_files(
     root: &Path,
     max_file_size: u64,
     max_parse_size_kb: usize,
+    options: ScanOptions,
     scan_t0: std::time::Instant,
     emit: &dyn Fn(&str, u8),
     cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> Vec<FileNode> {
     emit("Collecting files\u{2026}", 5);
-    let collected = collect_paths(root, max_file_size * 1024);
+    let collected = collect_paths(root, max_file_size * 1024, options);
     let total_files = collected.len();
     crate::debug_log!("[scan] collect_paths: {:.1}ms ({} files)", scan_t0.elapsed().as_secs_f64() * 1000.0, total_files);
 
@@ -375,6 +410,25 @@ pub fn scan_directory(
     limits: &ScanLimits,
     cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<ScanResult, AppError> {
+    scan_directory_with_options(
+        root_path,
+        on_progress,
+        on_tree_ready,
+        limits,
+        cancel,
+        ScanOptions::default(),
+    )
+}
+
+/// Main scan function with caller-selected scan options.
+pub fn scan_directory_with_options(
+    root_path: &str,
+    on_progress: Option<&dyn Fn(ScanProgress)>,
+    on_tree_ready: Option<&dyn Fn(Snapshot)>,
+    limits: &ScanLimits,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
+    options: ScanOptions,
+) -> Result<ScanResult, AppError> {
     let scan_t0 = std::time::Instant::now();
     let root = Path::new(root_path);
     if !root.exists() || !root.is_dir() {
@@ -390,7 +444,7 @@ pub fn scan_directory(
     // Single pass: collect + scan + parse per file (no tokei, no separate parse phase)
     let mut files = walk_and_scan_files(
         root, limits.max_file_size_kb, limits.max_parse_size_kb,
-        scan_t0, &emit, cancel,
+        options, scan_t0, &emit, cancel,
     );
 
     // Check cancel
@@ -406,6 +460,65 @@ pub fn scan_directory(
         root, max_call_targets: limits.max_call_targets, scan_t0, emit: &emit, on_tree_ready,
     };
     Ok(build_tree_and_graphs(files, &bctx))
+}
+
+#[cfg(test)]
+mod scan_options_tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn include_untracked_adds_git_worktree_files() {
+        let root = std::env::temp_dir().join(format!(
+            "sentrux-include-untracked-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        let result = (|| {
+            run_git(&root, &["init"]);
+            fs::write(root.join("tracked.rs"), "pub fn tracked() {}\n").unwrap();
+            run_git(&root, &["add", "tracked.rs"]);
+            fs::write(root.join("new_file.rs"), "pub fn new_file() {}\n").unwrap();
+
+            let limits = ScanLimits {
+                max_file_size_kb: 2048,
+                max_parse_size_kb: 512,
+                max_call_targets: 5,
+            };
+            let root_str = root.to_str().unwrap();
+            let tracked_only = scan_directory(root_str, None, None, &limits, None).unwrap();
+            let with_untracked = scan_directory_with_options(
+                root_str,
+                None,
+                None,
+                &limits,
+                None,
+                ScanOptions { include_untracked: true },
+            ).unwrap();
+
+            assert_eq!(tracked_only.snapshot.total_files, 1);
+            assert_eq!(with_untracked.snapshot.total_files, 2);
+        })();
+
+        let _ = fs::remove_dir_all(&root);
+        result
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 /// Re-export for backward compatibility.

--- a/sentrux-core/src/app/mcp_server/handlers.rs
+++ b/sentrux-core/src/app/mcp_server/handlers.rs
@@ -19,10 +19,13 @@ use std::sync::Arc;
 
 // ── Scan helper (shared by scan, rescan, session_end) ──
 
-pub(crate) fn do_scan(root: &Path) -> Result<(Snapshot, metrics::HealthReport, arch::ArchReport), String> {
+pub(crate) fn do_scan_with_options(
+    root: &Path,
+    options: scanner::ScanOptions,
+) -> Result<(Snapshot, metrics::HealthReport, arch::ArchReport), String> {
     let root_str = root.to_str().ok_or("Invalid path encoding")?;
     let s = crate::core::settings::Settings::default();
-    let result = scanner::scan_directory(
+    let result = scanner::scan_directory_with_options(
         root_str,
         None,
         None,
@@ -32,6 +35,7 @@ pub(crate) fn do_scan(root: &Path) -> Result<(Snapshot, metrics::HealthReport, a
             max_call_targets: s.max_call_targets,
         },
         None, // MCP scans are not cancellable
+        options,
     ).map_err(|e| format!("Scan failed: {e}"))?;
     let arch_report = arch::compute_arch(&result.snapshot);
     let health = metrics::compute_health(&result.snapshot);
@@ -50,7 +54,12 @@ pub fn scan_def() -> ToolDef {
         input_schema: json!({
             "type": "object",
             "properties": {
-                "path": { "type": "string", "description": "Absolute path to the directory to scan" }
+                "path": { "type": "string", "description": "Absolute path to the directory to scan" },
+                "include_untracked": {
+                    "type": "boolean",
+                    "description": "Include untracked, non-ignored Git worktree files in the scan",
+                    "default": false
+                }
             },
             "required": ["path"]
         }),
@@ -69,10 +78,18 @@ fn handle_scan(args: &Value, _tier: &Tier, state: &mut McpState) -> Result<Value
         return Err(format!("Not a directory: {path}"));
     }
 
-    let (snapshot, health, arch_report) = do_scan(&root)?;
+    let include_untracked = args.get("include_untracked")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let (snapshot, health, arch_report) = do_scan_with_options(
+        &root,
+        scanner::ScanOptions { include_untracked },
+    )?;
 
     let result = json!({
         "scanned": path,
+        "include_untracked": include_untracked,
         "quality_signal": (health.quality_signal * 10000.0).round() as u32,
         "files": snapshot.total_files,
         "lines": snapshot.total_lines,
@@ -208,23 +225,39 @@ pub fn session_end_def() -> ToolDef {
     ToolDef {
         name: "session_end",
         description: "Re-scan and compare current state against session baseline. Returns diff showing what degraded.",
-        input_schema: json!({ "type": "object", "properties": {} }),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "include_untracked": {
+                    "type": "boolean",
+                    "description": "Include untracked, non-ignored Git worktree files in the scan",
+                    "default": false
+                }
+            }
+        }),
         min_tier: Tier::Free,
         handler: handle_session_end,
         invalidates_evolution: true,
     }
 }
 
-fn handle_session_end(_args: &Value, _tier: &Tier, state: &mut McpState) -> Result<Value, String> {
+fn handle_session_end(args: &Value, _tier: &Tier, state: &mut McpState) -> Result<Value, String> {
     // Clone to avoid borrow conflict: we read root+baseline, then mutate state.
     let root = state.scan_root.clone().ok_or("No scan root. Call 'scan' first.")?;
     let baseline = state.baseline.clone().ok_or("No baseline saved. Call 'session_start' first.")?;
 
-    let (snapshot, health, arch_report) = do_scan(&root)?;
+    let include_untracked = args.get("include_untracked")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let (snapshot, health, arch_report) = do_scan_with_options(
+        &root,
+        scanner::ScanOptions { include_untracked },
+    )?;
     let diff = baseline.diff(&health);
 
     let result = json!({
         "pass": !diff.degraded,
+        "include_untracked": include_untracked,
         "signal_before": (diff.signal_before * 10000.0).round() as i32,
         "signal_after": (diff.signal_after * 10000.0).round() as i32,
         "signal_delta": ((diff.signal_after - diff.signal_before) * 10000.0).round() as i32,
@@ -249,20 +282,36 @@ pub fn rescan_def() -> ToolDef {
     ToolDef {
         name: "rescan",
         description: "Re-scan the current directory to pick up file changes since last scan.",
-        input_schema: json!({ "type": "object", "properties": {} }),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "include_untracked": {
+                    "type": "boolean",
+                    "description": "Include untracked, non-ignored Git worktree files in the scan",
+                    "default": false
+                }
+            }
+        }),
         min_tier: Tier::Free,
         handler: handle_rescan,
         invalidates_evolution: true,
     }
 }
 
-fn handle_rescan(_args: &Value, _tier: &Tier, state: &mut McpState) -> Result<Value, String> {
+fn handle_rescan(args: &Value, _tier: &Tier, state: &mut McpState) -> Result<Value, String> {
     // Clone root to avoid borrow conflict
     let root = state.scan_root.clone().ok_or("No scan root. Call 'scan' first.")?;
-    let (snapshot, health, arch_report) = do_scan(&root)?;
+    let include_untracked = args.get("include_untracked")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let (snapshot, health, arch_report) = do_scan_with_options(
+        &root,
+        scanner::ScanOptions { include_untracked },
+    )?;
 
     let result = json!({
         "status": "Rescanned",
+        "include_untracked": include_untracked,
         "quality_signal": (health.quality_signal * 10000.0).round() as u32,
         "files": snapshot.total_files
     });


### PR DESCRIPTION
## Summary

Adds an explicit opt-in path for scanning untracked, non-ignored Git worktree files.

- Adds `ScanOptions { include_untracked }` and `scan_directory_with_options` while preserving the existing `scan_directory` default behavior.
- Adds `sentrux check --include-untracked` for CLI quality gates.
- Adds optional `include_untracked` support to MCP `scan`, `rescan`, and `session_end` tool calls.
- Adds a scanner regression test showing tracked-only scans exclude untracked files while opt-in scans include them.

## Background

Sentrux currently uses `git ls-files` as the source of truth for project files. That is a good default for committed source, CI, and normal developer workflows: it is deterministic, respects Git, avoids ignored build artifacts, and does not rely on heuristic filesystem walking.

The gap shows up in AI-agent workflows. Agents often create new source files and immediately run quality gates before staging or committing. In that window, `git ls-files` does not include the new files, so `sentrux check .` and MCP scans can report on an incomplete version of the worktree. That can let a session pass even though newly generated files introduce architectural violations, excessive size, bad layering, or other structural issues.

A wrapper can work around this by creating a temporary Git index and adding the proposed worktree there, but that is brittle and pushes product behavior into every downstream integration. It is better for Sentrux to expose this as a first-class scan mode.

## Why an explicit flag

This PR keeps the existing default unchanged. `sentrux check .` still scans tracked files only, which preserves existing CI behavior and avoids suddenly pulling in local scratch files.

The new flag is opt-in:

```sh
sentrux check . --include-untracked
```

For MCP clients, the same behavior is available through an optional `include_untracked` boolean on `scan`, `rescan`, and `session_end`.

The implementation only includes untracked files that Git itself considers non-ignored via:

```sh
git ls-files --others --exclude-standard
```

So ignored build outputs, caches, and local artifacts remain excluded.

## Impact

This gives AI agents and editor integrations a deterministic way to evaluate the full proposed worktree before staging. It should reduce false confidence during agent runs without changing the default behavior for existing users.

## Validation

- `git diff --check` passed.
- Targeted Cargo test was attempted with `cargo test -p sentrux-core include_untracked_adds_git_worktree_files`, but this local Windows environment cannot complete Rust builds because the MSVC linker environment is incomplete (`link.exe` is not available through Cargo's build environment). The test is included for CI/maintainer verification.