### PR TITLE
Name complex-function gate regressions; rules exceptions

### DIFF
--- a/sentrux-core/src/app/mcp_server/handlers.rs
+++ b/sentrux-core/src/app/mcp_server/handlers.rs
@@ -231,6 +231,16 @@ fn handle_session_end(_args: &Value, _tier: &Tier, state: &mut McpState) -> Resu
         "coupling_change": [diff.coupling_before, diff.coupling_after],
         "cycles_change": [diff.cycles_before, diff.cycles_after],
         "violations": diff.violations,
+        "new_complex_functions": diff.new_complex_functions.iter().map(|f| json!({
+            "file": f.file,
+            "func": f.func,
+            "cc": f.cc,
+        })).collect::<Vec<_>>(),
+        "removed_complex_functions": diff.removed_complex_functions.iter().map(|f| json!({
+            "file": f.file,
+            "func": f.func,
+            "cc": f.cc,
+        })).collect::<Vec<_>>(),
         "summary": if diff.degraded { "Quality degraded" } else { "Quality stable or improved" }
     });
 

--- a/sentrux-core/src/metrics/arch/mod.rs
+++ b/sentrux-core/src/metrics/arch/mod.rs
@@ -113,6 +113,36 @@ pub struct ArchReport {
     //  — proxy metrics, all captured by root cause modularity Q)
 }
 
+/// One complex function entry stored in a baseline for gate/session diffs.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ComplexFnSnapshot {
+    pub file: String,
+    pub func: String,
+    pub cc: u32,
+}
+
+impl ComplexFnSnapshot {
+    fn from_func_metric(m: &crate::metrics::FuncMetric) -> Self {
+        Self {
+            file: m.file.clone(),
+            func: m.func.clone(),
+            cc: m.value,
+        }
+    }
+
+    fn key(&self) -> String {
+        format!("{}::{}", self.file, self.func)
+    }
+}
+
+fn complex_fn_snapshots(report: &crate::metrics::HealthReport) -> Vec<ComplexFnSnapshot> {
+    report
+        .complex_functions
+        .iter()
+        .map(ComplexFnSnapshot::from_func_metric)
+        .collect()
+}
+
 /// Baseline snapshot for session diff / structural regression gate.
 /// Captured at session start; subsequent scans compare against this
 /// to detect regressions (e.g., quality_signal drop, new cycles).
@@ -138,6 +168,9 @@ pub struct ArchBaseline {
     pub total_import_edges: usize,
     /// Cross-module import edges at baseline
     pub cross_module_edges: usize,
+    /// Complex functions (CC > language threshold) at baseline — optional for backward compat.
+    #[serde(default)]
+    pub complex_functions: Vec<ComplexFnSnapshot>,
 }
 
 /// Diff between two snapshots (baseline vs current).
@@ -163,6 +196,10 @@ pub struct ArchDiff {
     pub degraded: bool,
     /// Human-readable violation descriptions
     pub violations: Vec<String>,
+    /// Complex functions present in current scan but not in baseline
+    pub new_complex_functions: Vec<ComplexFnSnapshot>,
+    /// Complex functions present in baseline but no longer complex in current scan
+    pub removed_complex_functions: Vec<ComplexFnSnapshot>,
 }
 
 // ── Baseline Save/Load ──
@@ -184,6 +221,7 @@ impl ArchBaseline {
             max_depth: report.max_depth,
             total_import_edges: report.total_import_edges,
             cross_module_edges: report.cross_module_edges,
+            complex_functions: complex_fn_snapshots(report),
         }
     }
 
@@ -237,12 +275,28 @@ impl ArchBaseline {
                 current.god_files.len()
             ));
         }
+        let current_complex = complex_fn_snapshots(current);
+        let legacy_baseline = self.complex_functions.is_empty() && self.complex_fn_count > 0;
+        let (new_complex_functions, removed_complex_functions) = if legacy_baseline {
+            (Vec::new(), Vec::new())
+        } else {
+            diff_complex_functions(&self.complex_functions, &current_complex)
+        };
+
         if current.complex_functions.len() > self.complex_fn_count {
             violations.push(format!(
                 "Complex functions increased: {} → {}",
                 self.complex_fn_count,
                 current.complex_functions.len()
             ));
+        }
+        if !legacy_baseline {
+            for f in &new_complex_functions {
+                violations.push(format!(
+                    "New complex function: {}::{} (cc={})",
+                    f.file, f.func, f.cc
+                ));
+            }
         }
 
         let degraded = current.quality_signal < self.quality_signal - 0.02
@@ -259,8 +313,33 @@ impl ArchBaseline {
             god_files_after: current.god_files.len(),
             degraded,
             violations,
+            new_complex_functions,
+            removed_complex_functions,
         }
     }
+}
+
+/// Set-diff complex function snapshots by `file::func` key.
+fn diff_complex_functions(
+    before: &[ComplexFnSnapshot],
+    after: &[ComplexFnSnapshot],
+) -> (Vec<ComplexFnSnapshot>, Vec<ComplexFnSnapshot>) {
+    use std::collections::HashSet;
+
+    let before_keys: HashSet<String> = before.iter().map(ComplexFnSnapshot::key).collect();
+    let after_keys: HashSet<String> = after.iter().map(ComplexFnSnapshot::key).collect();
+
+    let new_fns: Vec<ComplexFnSnapshot> = after
+        .iter()
+        .filter(|f| !before_keys.contains(&f.key()))
+        .cloned()
+        .collect();
+    let removed_fns: Vec<ComplexFnSnapshot> = before
+        .iter()
+        .filter(|f| !after_keys.contains(&f.key()))
+        .cloned()
+        .collect();
+    (new_fns, removed_fns)
 }
 
 // ── Grading ──

--- a/sentrux-core/src/metrics/arch/tests.rs
+++ b/sentrux-core/src/metrics/arch/tests.rs
@@ -169,6 +169,7 @@ fn baseline_detects_degradation() {
         max_depth: 3,
         total_import_edges: 10,
         cross_module_edges: 1,
+        complex_functions: vec![],
     };
 
     let current = crate::metrics::HealthReport {
@@ -228,4 +229,113 @@ fn baseline_detects_degradation() {
     assert!(diff.violations.iter().any(|v| v.contains("Cycles")));
     assert!(diff.violations.iter().any(|v| v.contains("God files")));
     assert!(diff.violations.iter().any(|v| v.contains("Complex functions")));
+}
+
+#[test]
+fn baseline_diff_names_new_complex_functions() {
+    let baseline = ArchBaseline {
+        timestamp: 0.0,
+        quality_signal: 0.90,
+        coupling_score: 0.10,
+        cycle_count: 0,
+        god_file_count: 0,
+        hotspot_count: 0,
+        complex_fn_count: 2,
+        max_depth: 3,
+        total_import_edges: 10,
+        cross_module_edges: 1,
+        complex_functions: vec![
+            ComplexFnSnapshot {
+                file: "a.rs".into(),
+                func: "keep".into(),
+                cc: 16,
+            },
+            ComplexFnSnapshot {
+                file: "b.rs".into(),
+                func: "gone".into(),
+                cc: 17,
+            },
+        ],
+    };
+
+    let current = crate::metrics::HealthReport {
+        coupling_score: 0.10,
+        circular_dep_count: 0,
+        circular_dep_files: vec![],
+        total_import_edges: 10,
+        cross_module_edges: 1,
+        entropy: 0.5,
+        entropy_bits: 1.5,
+        avg_cohesion: Some(0.3),
+        max_depth: 3,
+        god_files: vec![],
+        hotspot_files: vec![],
+        most_unstable: vec![],
+        complex_functions: vec![
+            crate::metrics::FuncMetric {
+                file: "a.rs".into(),
+                func: "keep".into(),
+                value: 16,
+            },
+            crate::metrics::FuncMetric {
+                file: "c.rs".into(),
+                func: "new_one".into(),
+                value: 18,
+            },
+            crate::metrics::FuncMetric {
+                file: "d.rs".into(),
+                func: "new_two".into(),
+                value: 20,
+            },
+        ],
+        long_functions: vec![],
+        cog_complex_functions: vec![],
+        high_param_functions: vec![],
+        duplicate_groups: vec![],
+        dead_functions: vec![],
+        long_files: vec![],
+        all_function_ccs: vec![],
+        all_function_lines: vec![],
+        all_file_lines: vec![],
+        god_file_ratio: 0.0,
+        hotspot_ratio: 0.0,
+        complex_fn_ratio: 0.08,
+        long_fn_ratio: 0.0,
+        comment_ratio: Some(0.1),
+        large_file_count: 0,
+        large_file_ratio: 0.0,
+        duplication_ratio: 0.0,
+        dead_code_ratio: 0.0,
+        high_param_ratio: 0.0,
+        cog_complex_ratio: 0.0,
+        quality_signal: 0.90,
+        root_cause_raw: crate::metrics::root_causes::RootCauseRaw {
+            modularity_q: 0.3,
+            cycle_count: 0,
+            max_depth: 3,
+            complexity_gini: 0.3,
+            redundancy_ratio: 0.1,
+        },
+        root_cause_scores: crate::metrics::root_causes::RootCauseScores {
+            modularity: 0.53,
+            acyclicity: 0.33,
+            depth: 0.62,
+            equality: 0.7,
+            redundancy: 0.9,
+        },
+    };
+
+    let diff = baseline.diff(&current);
+    assert!(diff.degraded);
+    assert_eq!(diff.new_complex_functions.len(), 2);
+    assert!(diff
+        .new_complex_functions
+        .iter()
+        .any(|f| f.file == "c.rs" && f.func == "new_one"));
+    assert!(diff
+        .new_complex_functions
+        .iter()
+        .any(|f| f.file == "d.rs" && f.func == "new_two"));
+    assert_eq!(diff.removed_complex_functions.len(), 1);
+    assert!(diff.violations.iter().any(|v| v.contains("new_one")));
 }

--- a/sentrux-core/src/metrics/arch/tests2.rs
+++ b/sentrux-core/src/metrics/arch/tests2.rs
@@ -21,6 +21,7 @@ fn baseline_stable_no_degradation() {
         max_depth: 4,
         total_import_edges: 15,
         cross_module_edges: 5,
+        complex_functions: vec![],
     };
 
     let current = crate::metrics::HealthReport {

--- a/sentrux-core/src/metrics/rules/mod.rs
+++ b/sentrux-core/src/metrics/rules/mod.rs
@@ -52,6 +52,22 @@ pub struct RulesConfig {
     /// Explicit deny rules between file patterns.
     #[serde(default)]
     pub boundaries: Vec<BoundaryRule>,
+
+    /// Known false-positive import edges to suppress (suffix resolver noise).
+    #[serde(default)]
+    pub exceptions: Vec<ExceptionRule>,
+}
+
+/// Suppress a layer/boundary violation for a specific import edge.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExceptionRule {
+    /// Glob pattern for source files.
+    pub from: String,
+    /// Glob pattern for target files.
+    pub to: String,
+    /// Human-readable reason (documented in rules.toml header).
+    #[serde(default)]
+    pub reason: String,
 }
 
 /// Per-language section in rules.toml.
@@ -174,13 +190,13 @@ pub fn check_rules(
     // ── Layer checks ──
     if config.layers.len() >= 2 {
         rules_checked += 1;
-        violations.extend(check_layers(&config.layers, edges));
+        violations.extend(check_layers(&config.layers, &config.exceptions, edges));
     }
 
     // ── Boundary checks ──
     for boundary in &config.boundaries {
         rules_checked += 1;
-        violations.extend(check_boundary(boundary, edges));
+        violations.extend(check_boundary(boundary, &config.exceptions, edges));
     }
 
     let passed = violations.iter().all(|v| v.severity != Severity::Error);
@@ -189,7 +205,17 @@ pub fn check_rules(
 
 /// Check layer ordering: files in higher layers must not import files in lower layers.
 /// Layers are ordered by their `order` field or array position (first = highest/presentation, last = lowest/infrastructure).
-fn check_layers(layers: &[LayerDef], edges: &[ImportEdge]) -> Vec<RuleViolation> {
+fn is_exception(exceptions: &[ExceptionRule], from: &str, to: &str) -> bool {
+    exceptions
+        .iter()
+        .any(|e| glob_match(&e.from, from) && glob_match(&e.to, to))
+}
+
+fn check_layers(
+    layers: &[LayerDef],
+    exceptions: &[ExceptionRule],
+    edges: &[ImportEdge],
+) -> Vec<RuleViolation> {
     let mut violations = Vec::new();
 
     // Assign order to each layer (lower order = more foundational = can be depended on)
@@ -211,7 +237,7 @@ fn check_layers(layers: &[LayerDef], edges: &[ImportEdge]) -> Vec<RuleViolation>
             // Violation: importing from a higher-order (less foundational) layer
             // Lower order = more foundational. A file in order=2 importing order=0 is wrong
             // (infrastructure importing presentation).
-            if from_ord > to_ord {
+            if from_ord > to_ord && !is_exception(exceptions, &edge.from_file, &edge.to_file) {
                 violations.push(RuleViolation {
                     rule: "layer_direction".into(),
                     severity: Severity::Error,
@@ -287,11 +313,18 @@ pub(crate) fn glob_match(pattern: &str, path: &str) -> bool {
 }
 
 /// Check a single boundary rule against all edges.
-fn check_boundary(rule: &BoundaryRule, edges: &[ImportEdge]) -> Vec<RuleViolation> {
+fn check_boundary(
+    rule: &BoundaryRule,
+    exceptions: &[ExceptionRule],
+    edges: &[ImportEdge],
+) -> Vec<RuleViolation> {
     let mut violations = Vec::new();
 
     for edge in edges {
-        if glob_match(&rule.from, &edge.from_file) && glob_match(&rule.to, &edge.to_file) {
+        if glob_match(&rule.from, &edge.from_file)
+            && glob_match(&rule.to, &edge.to_file)
+            && !is_exception(exceptions, &edge.from_file, &edge.to_file)
+        {
             violations.push(RuleViolation {
                 rule: "boundary".into(),
                 severity: Severity::Error,


### PR DESCRIPTION
## Summary
- Add optional `complex_functions` to `ArchBaseline` for set-diff naming on gate regression (Free tier)
- Extend MCP `session_end` JSON with `new_complex_functions` / `removed_complex_functions`
- Add `[[exceptions]]` to `.sentrux/rules.toml` for documented false-positive import edges

## Motivation
Gate regression currently reports only `complex_fn_count` deltas (e.g. 120→124) with no function names on Free tier. GIP SDK remediation needed named diffs to fix +4 regression without Pro diagnostics.

## Test plan
- [x] `cargo test -p sentrux-core metrics::arch::tests`
- [ ] Upstream maintainer review