### PR TITLE
fix(dart): capture declaration wrapper so definition.function includes the body

### DIFF
--- a/plugins/dart/plugin.toml
+++ b/plugins/dart/plugin.toml
@@ -1,7 +1,7 @@
 [plugin]
 name = "dart"
 display_name = "Dart"
-version = "0.2.0"
+version = "0.2.1"
 extensions = ["dart"]
 min_sentrux_version = "0.4.0"
 color_rgb = [100, 180, 220]

--- a/plugins/dart/queries/tags.scm
+++ b/plugins/dart/queries/tags.scm
@@ -4,8 +4,9 @@
 
 ; ── Definitions ──
 
-(function_signature
-  name: (identifier) @name) @definition.function
+(declaration
+  (function_signature
+    name: (identifier) @name)) @definition.function
 
 (class_definition
   name: (identifier) @name) @definition.class


### PR DESCRIPTION
Fixes #64 

## Problem

For every Dart project, the `redundancy` axis reports raw `1.0` (score 0) regardless of actual duplication, permanently crushing `quality_signal` for Dart codebases.

Root cause: in tree-sitter-dart (UserNobody14), `function_signature` does **not** contain the function body — `function_body` is a **sibling** node. The Dart `tags.scm` captures `@definition.function` on `function_signature`, so body extraction yields an empty body for every function → all functions hash as mutual clones → redundancy pegged at worst-case.

Smoking-gun evidence: a fixture with 6 functions + 1 class yields raw redundancy = exactly **6/7** — all functions are "clones" of each other, and the class is the only distinct unit because `class_definition` spans its whole body.

## Change

- `plugins/dart/queries/tags.scm`: capture the wrapping `declaration` (which contains both `function_signature` and `function_body`) instead of the bare signature.
- `plugins/dart/plugin.toml`: version 0.2.0 → 0.2.1 (drop this if plugin versioning is handled elsewhere).

## Testing

- `sentrux plugin validate plugins/dart` → `queries/tags.scm: OK (captures valid)` (grammar dylib not shipped in-tree, as before).
- Fixture repo (6 functions incl. 1 duplicate pair + 1 class): quality 5313 → 6826, redundancy raw 0.857 (degenerate 6/7) → ≈ 0.50.
- Real 191k-LOC Flutter monorepo: quality_signal 2451 → 4967, redundancy raw 1.0 → ≈ 0.66.
- Cross-language sanity: Python same-shape fixtures unaffected (already correct: 0.5 for two distinct functions, 0.0 for zero functions).

## Open questions

1. Class members (methods/getters/setters/constructors) may need additional patterns to be included in function extraction — this PR fixes top-level functions, which already unblocks the axis.
2. The `equality` axis also shifts once functions are actually extracted (unit counts per module change) — assumed intended, flagging for awareness.
