### PR TITLE
reverse layers.order compare logic, and add 规则说明.md to explain the params in rules.toml

### DIFF
--- a/sentrux-core/src/metrics/rules/mod.rs
+++ b/sentrux-core/src/metrics/rules/mod.rs
@@ -293,7 +293,20 @@ fn check_boundary(rule: &BoundaryRule, edges: &[ImportEdge]) -> Vec<RuleViolatio
     let mut violations = Vec::new();
 
     for edge in edges {
-        if glob_match(&rule.from, &edge.from_file) && glob_match(&rule.to, &edge.to_file) {
+        // m_from: the rule's `from` glob matches this edge's importer — the file that
+        // contains the import statement (the dependent side).
+        // m_to: the rule's `to` glob matches this edge's imported file — the dependency
+        // target. The two checks are independent; a violation requires BOTH on the same edge.
+        let m_from = glob_match(&rule.from, &edge.from_file);
+        let m_to = glob_match(&rule.to, &edge.to_file);
+        // Three possible outcomes per edge (false/false is trivially allowed):
+        //   (true, false) — importer is in the restricted group, but the target is not the
+        //     forbidden group (e.g. renderer imports core). Not the forbidden pattern: allowed.
+        //   (false, true) — target is in the forbidden group, but the importer is not the
+        //     restricted source (e.g. metrics imports analysis). Allowed.
+        //   (true, true)  — an actual "from-group file imports to-group file" dependency
+        //     exists: exactly what this deny rule forbids → violation.
+        if m_from && m_to {
             violations.push(RuleViolation {
                 rule: "boundary".into(),
                 severity: Severity::Error,

--- a/sentrux-core/src/metrics/rules/mod.rs
+++ b/sentrux-core/src/metrics/rules/mod.rs
@@ -81,7 +81,8 @@ pub struct LayerDef {
     pub name: String,
     /// Glob patterns matching files in this layer (e.g., "src/ui/*").
     pub paths: Vec<String>,
-    /// Layer order (lower = more foundational). Layers can only depend downward.
+    /// Layer order (lower = more foundational like core/infrastructure, higher = higher layer like app/presentation).
+    /// Dependencies flow upward: foundational layers can be imported by higher layers, but not vice versa.
     /// If not specified, order is determined by position in the array.
     pub order: Option<u32>,
 }
@@ -187,12 +188,13 @@ pub fn check_rules(
     RuleCheckResult { passed, violations, rules_checked }
 }
 
-/// Check layer ordering: files in higher layers must not import files in lower layers.
-/// Layers are ordered by their `order` field or array position (first = highest/presentation, last = lowest/infrastructure).
+/// Check layer ordering: files in lower layers (more foundational) must not import files in higher layers.
+/// Layers are ordered by their `order` field: lower order = more foundational (core/infrastructure), higher order = higher layer (app/presentation).
+/// Dependencies must flow upward: foundational layers can be imported by higher layers, but not vice versa.
 fn check_layers(layers: &[LayerDef], edges: &[ImportEdge]) -> Vec<RuleViolation> {
     let mut violations = Vec::new();
 
-    // Assign order to each layer (lower order = more foundational = can be depended on)
+    // Assign order to each layer (lower order = more foundational, higher order = higher layer)
     let layer_order: Vec<(usize, &LayerDef)> = layers
         .iter()
         .enumerate()
@@ -208,10 +210,10 @@ fn check_layers(layers: &[LayerDef], edges: &[ImportEdge]) -> Vec<RuleViolation>
         let to_layer = find_layer(&edge.to_file, &layer_order);
 
         if let (Some((from_ord, from_name)), Some((to_ord, to_name))) = (from_layer, to_layer) {
-            // Violation: importing from a higher-order (less foundational) layer
-            // Lower order = more foundational. A file in order=2 importing order=0 is wrong
-            // (infrastructure importing presentation).
-            if from_ord > to_ord {
+            // Violation: a foundational layer (lower order) imports a higher layer (higher order)
+            // Lower order = more foundational. A file in order=0 importing order=2 is wrong
+            // (core layer must not depend on app layer).
+            if from_ord < to_ord {
                 violations.push(RuleViolation {
                     rule: "layer_direction".into(),
                     severity: Severity::Error,

--- a/sentrux-core/src/metrics/rules/tests.rs
+++ b/sentrux-core/src/metrics/rules/tests.rs
@@ -66,8 +66,8 @@ no_god_files = true
 max_upward_violations = 0
 
 [[layers]]
-name = "presentation"
-paths = ["src/ui/*", "src/renderer/*"]
+name = "infrastructure"
+paths = ["src/scanner.rs", "src/watcher.rs", "src/git.rs"]
 order = 0
 
 [[layers]]
@@ -76,8 +76,8 @@ paths = ["src/metrics.rs", "src/graph.rs", "src/arch.rs"]
 order = 1
 
 [[layers]]
-name = "infrastructure"
-paths = ["src/scanner.rs", "src/watcher.rs", "src/git.rs"]
+name = "presentation"
+paths = ["src/ui/*", "src/renderer/*"]
 order = 2
 
 [[boundaries]]
@@ -89,7 +89,7 @@ reason = "Renderer must not know about scanning"
         assert!((config.constraints.min_quality.unwrap() - 0.4).abs() < 0.01);
         assert!((config.constraints.max_coupling_score.unwrap() - 0.35).abs() < 0.01);
         assert_eq!(config.layers.len(), 3);
-        assert_eq!(config.layers[0].name, "presentation");
+        assert_eq!(config.layers[0].name, "infrastructure");
         assert_eq!(config.boundaries.len(), 1);
         assert_eq!(config.boundaries[0].reason, "Renderer must not know about scanning");
     }
@@ -170,17 +170,17 @@ max_cycles = 5
     fn layer_violation_detected() {
         let config: RulesConfig = toml::from_str(r#"
 [[layers]]
-name = "presentation"
-paths = ["src/ui/*"]
+name = "infrastructure"
+paths = ["src/scanner.rs"]
 order = 0
 
 [[layers]]
-name = "infrastructure"
-paths = ["src/scanner.rs"]
+name = "presentation"
+paths = ["src/ui/*"]
 order = 2
 "#).unwrap();
 
-        // Infrastructure imports presentation = violation
+        // Infrastructure (foundational, order=0) imports presentation (higher layer, order=2) = violation
         let edges = vec![edge("src/scanner.rs", "src/ui/panel.rs")];
         let snap = make_snapshot(edges.clone(), vec![
             file("src/scanner.rs"),
@@ -198,17 +198,17 @@ order = 2
     fn layer_correct_direction_passes() {
         let config: RulesConfig = toml::from_str(r#"
 [[layers]]
-name = "presentation"
-paths = ["src/ui/*"]
+name = "infrastructure"
+paths = ["src/scanner.rs"]
 order = 0
 
 [[layers]]
-name = "infrastructure"
-paths = ["src/scanner.rs"]
+name = "presentation"
+paths = ["src/ui/*"]
 order = 2
 "#).unwrap();
 
-        // Presentation imports infrastructure = correct direction
+        // Presentation (higher layer, order=2) imports infrastructure (foundational, order=0) = correct direction
         let edges = vec![edge("src/ui/panel.rs", "src/scanner.rs")];
         let snap = make_snapshot(edges.clone(), vec![
             file("src/ui/panel.rs"),

--- a/sentrux-core/src/metrics/rules/tests.rs
+++ b/sentrux-core/src/metrics/rules/tests.rs
@@ -129,6 +129,16 @@ reason = "Renderer must not know about scanning"
         assert!(!glob_match("*.rs", "src/app.ts"));
     }
 
+    #[test]
+    fn glob_has_no_middle_wildcard_support() {
+        // `*`/`**` only work as a trailing segment. Patterns are matched verbatim
+        // against scan-root-relative paths, so crate-prefixed workspace paths
+        // ("sentrux-core/src/...") need the prefix spelled out in the pattern.
+        assert!(!glob_match("*/src/renderer/*", "sentrux-core/src/renderer/x.rs"));
+        assert!(!glob_match("src/renderer/*", "sentrux-core/src/renderer/x.rs"));
+        assert!(glob_match("sentrux-core/src/renderer/*", "sentrux-core/src/renderer/x.rs"));
+    }
+
     // ── Constraint checks ──
 
     #[test]
@@ -272,6 +282,192 @@ to = "src/scanner.rs"
             .filter(|v| v.rule == "boundary")
             .collect();
         assert!(boundary_violations.is_empty());
+    }
+
+    // ── Boundary scenarios (from the _dbg_fixture experiment) ──
+    //
+    // Mirrors `.sentrux/rules.toml`: 6 layers (lower order = more foundational,
+    // dependencies must flow from higher to lower) plus the two deny boundaries.
+    // These cases pin down how boundary checks differ from the layer order check.
+
+    fn fixture_style_config() -> RulesConfig {
+        toml::from_str(r#"
+[[layers]]
+name = "core"
+paths = ["src/core/*"]
+order = 0
+
+[[layers]]
+name = "analysis"
+paths = ["src/analysis/*"]
+order = 1
+
+[[layers]]
+name = "metrics"
+paths = ["src/metrics/*"]
+order = 2
+
+[[layers]]
+name = "layout"
+paths = ["src/layout/*"]
+order = 3
+
+[[layers]]
+name = "renderer"
+paths = ["src/renderer/*"]
+order = 4
+
+[[layers]]
+name = "app"
+paths = ["src/app/*"]
+order = 5
+
+[[boundaries]]
+from = "src/renderer/*"
+to = "src/analysis/*"
+reason = "Renderer must not depend on analysis directly"
+
+[[boundaries]]
+from = "src/layout/*"
+to = "src/app/*"
+reason = "Layout must not depend on app layer"
+"#).unwrap()
+    }
+
+    #[test]
+    fn boundary_fires_even_when_layer_direction_is_legal() {
+        // renderer (order=4) imports analysis (order=1): higher -> lower is the LEGAL
+        // layer direction, so no layer_direction violation. The deny boundary is
+        // order-agnostic and still fires — this is the fixture group 1 scenario.
+        let config = fixture_style_config();
+        let edges = vec![edge("src/renderer/edges.rs", "src/analysis/graph.rs")];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("src/renderer/edges.rs"),
+            file("src/analysis/graph.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        assert!(!result.passed);
+        assert!(result.violations.iter().any(|v|
+            v.rule == "boundary" && v.message.contains("Renderer must not depend on analysis")
+        ));
+        assert!(result.violations.iter().all(|v| v.rule != "layer_direction"),
+            "higher -> lower is the legal layer direction, must not fire");
+    }
+
+    #[test]
+    fn boundary_and_layer_check_fire_together_for_wrong_direction() {
+        // layout (order=3) imports app (order=5): lower -> higher is the forbidden
+        // layer direction AND matches the layout -> app deny boundary, so BOTH rules
+        // fire — this is the fixture group 2 scenario.
+        let config = fixture_style_config();
+        let edges = vec![edge("src/layout/types.rs", "src/app/state.rs")];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("src/layout/types.rs"),
+            file("src/app/state.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        assert!(!result.passed);
+        assert!(result.violations.iter().any(|v| v.rule == "layer_direction"));
+        assert!(result.violations.iter().any(|v|
+            v.rule == "boundary" && v.message.contains("Layout must not depend on app")
+        ));
+    }
+
+    #[test]
+    fn boundary_from_match_only_is_allowed() {
+        // (m_from=true, m_to=false): renderer imports core. The importer is in the
+        // restricted group but the target is not the forbidden group; the layer
+        // direction is also legal (4 -> 0). Everything passes.
+        let config = fixture_style_config();
+        let edges = vec![edge("src/renderer/colors.rs", "src/core/types.rs")];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("src/renderer/colors.rs"),
+            file("src/core/types.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        assert!(result.passed);
+        assert!(result.violations.is_empty());
+    }
+
+    #[test]
+    fn boundary_is_directional_reverse_edge_does_not_fire() {
+        // analysis (order=1) imports renderer (order=4): the reverse of the deny
+        // rule. Boundaries only forbid the from -> to direction, so neither boundary
+        // fires; the wrong-direction edge is caught by the layer check instead.
+        let config = fixture_style_config();
+        let edges = vec![edge("src/analysis/graph.rs", "src/renderer/edges.rs")];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("src/analysis/graph.rs"),
+            file("src/renderer/edges.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        let boundary_violations: Vec<_> = result.violations.iter()
+            .filter(|v| v.rule == "boundary")
+            .collect();
+        assert!(boundary_violations.is_empty());
+        assert!(result.violations.iter().any(|v| v.rule == "layer_direction"),
+            "lower -> higher layer import must be caught by the layer check");
+    }
+
+    #[test]
+    fn boundary_patterns_match_scan_root_relative_paths_only() {
+        // Regression for the silent-pass root cause: when scanning a workspace root,
+        // edge paths carry the crate prefix ("sentrux-core/src/..."). glob_match has
+        // no middle-wildcard support, so "src/renderer/*" patterns match nothing and
+        // the boundary check silently passes. Patterns must spell out the prefix.
+        let config = fixture_style_config();
+        let edges = vec![edge(
+            "sentrux-core/src/renderer/colors.rs",
+            "sentrux-core/src/analysis/lang_registry.rs",
+        )];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("sentrux-core/src/renderer/colors.rs"),
+            file("sentrux-core/src/analysis/lang_registry.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        assert!(result.passed, "crate-prefixed paths never match the src/* patterns");
+        assert!(result.violations.is_empty());
+    }
+
+    #[test]
+    fn boundary_reports_one_violation_per_matching_edge() {
+        // Unlike layer_direction (deduplicated by message), check_boundary pushes
+        // one violation per matching edge — two importing files produce two reports.
+        let config = fixture_style_config();
+        let edges = vec![
+            edge("src/renderer/edges.rs", "src/analysis/graph.rs"),
+            edge("src/renderer/colors.rs", "src/analysis/lang_registry.rs"),
+        ];
+        let snap = make_snapshot(edges.clone(), vec![
+            file("src/renderer/edges.rs"),
+            file("src/renderer/colors.rs"),
+            file("src/analysis/graph.rs"),
+            file("src/analysis/lang_registry.rs"),
+        ]);
+        let health = metrics::compute_health(&snap);
+        let arch_report = arch::compute_arch(&snap);
+
+        let result = check_rules(&config, &health, &arch_report, &edges);
+        assert!(!result.passed);
+        let boundary_violations: Vec<_> = result.violations.iter()
+            .filter(|v| v.rule == "boundary")
+            .collect();
+        assert_eq!(boundary_violations.len(), 2);
     }
 
     // ── Empty rules pass everything ──

--- a/规则说明.md
+++ b/规则说明.md
@@ -1,0 +1,131 @@
+# Sentrux 规则说明（rules.toml 使用指南）
+
+本文面向 `sentrux check` 的使用者，说明 `.sentrux/rules.toml` 中各规则的含义、判定方式与使用注意事项，重点是 **layers 的 `order`** 与 **boundaries 的 `from`/`to`** 之间的关系。文中不涉及内部实现细节，所有判定行为均以实际输出为准。
+
+## 1. rules.toml 是什么、放在哪
+
+- 位置：被检查目录下的 `.sentrux/rules.toml`。例如 `sentrux check .` 会读取 `./.sentrux/rules.toml`。
+- 文件不存在时 `check` 会直接提示并失败；文件存在则按其中的规则逐条检查。
+- CLI 的 `sentrux check` 与 MCP 的 `check_rules` 工具使用同一套规则文件。
+- 文件由三部分组成：
+
+| 配置段 | 作用 |
+|---|---|
+| `[constraints]` | 各类阈值（最大环数、最大圈复杂度、最大函数行数等），写了才检查 |
+| `[[layers]]` | 定义分层及 `order`，检查**依赖方向**是否违反分层约定 |
+| `[[boundaries]]` | 点名禁止某类依赖（黑名单，更适用于跨层的禁止），与方向约定**无关** |
+
+## 2. layers：`order` 决定"依赖方向对不对"
+
+### 2.1 order 的约定
+
+> **order 越小越基础，越大越靠近应用层。依赖只能从大 order 流向小 order。**
+
+以本项目的配置为例：
+
+```
+core=0 → analysis=1 → metrics=2 → layout=3 → renderer=4 → app=5
+```
+
+- 合法方向：**大 order 依赖小 order**。如 `app(5)` 引 `core(0)`、`renderer(4)` 引 `analysis(1)` —— 正常。
+- 违规方向：**小 order 依赖大 order**。如 `core(0)` 引 `app(5)`、`layout(3)` 引 `app(5)` —— 报 `layer_direction` 违规。
+
+### 2.2 不写 order 会怎样
+
+`order` 可以省略，省略时按 layers 在文件中的**书写顺序**编号（第一条 = 0）。由于"靠位置隐式定序"很容易在调整段落顺序时被悄悄改变语义，**建议始终显式写出 `order`**。
+
+### 2.3 参与方向检查的前提
+
+一条 import 依赖只有当**起点和终点都命中某个 layer 的 `paths`** 时才参与方向判定：
+
+- 任一端文件不匹配任何 layer → 该条依赖不检查（既不违规也不算合规证据）。
+- `paths` 没覆盖到的文件不受 layer 约束。如果希望"全项目都被分层覆盖"，需要让各层 `paths` 合计覆盖所有源码目录。
+- layer 方向违规会按违规内容去重，同类违规只报一条。
+
+## 3. boundaries：点名禁止一条依赖
+
+### 3.1 语义
+
+> **`from` 匹配的文件，不得 import `to` 匹配的文件。**
+
+`from`/`to` 写的是**文件路径的匹配模式**（不是 layer 名）。一条 `[[boundaries]]` 只禁止 from→to 这**一个方向**；如果反向也要禁止，需要再写一条。
+
+### 3.2 一条依赖被判定为违规的三个条件
+
+1. 这是一次**真实存在的 import**（能解析到实际文件；解析失败的 import 不算数）；
+2. 依赖的**发起方**（写 import 的文件）命中 `from` 模式；
+3. 依赖的**目标方**（被引入的文件）命中 `to` 模式。
+
+三者必须发生在**同一条依赖**上。命中即报 `boundary` 违规，且**每一处命中单独报一条**（不做合并去重）——N 处违规 import 就报 N 条。
+
+## 4. 重点：`order` 与 `from`/`to` 的关系
+
+### 4.1 一句话分工
+
+- **layers 管"方向对不对"**：只看两端的 `order` 谁大谁小，低层引高层才违规。
+- **boundaries 管"这条依赖允不允许存在"**：只看路径模式匹配，**完全不读 `order`**。
+
+因此一条依赖可能出现三种结果：只违反 layer、只违反 boundary、或两者都违反。
+
+### 4.2 判定对照表（按本项目实际配置）
+
+| 依赖（发起方 → 目标方） | order 关系 | layers 判定 | boundaries 判定 | 最终结果 |
+|---|---|---|---|---|
+| `app(5)` → `core(0)` | 高→低 | 合法 | 未点名 | 通过 |
+| `renderer(4)` → `analysis(1)` | 高→低 | 合法 | **boundary #1 点名禁止** | **违规（boundary）** |
+| `layout(3)` → `app(5)` | 低→高 | **违规**（layer_direction） | **boundary #2 点名禁止** | **双重违规（两条都报）** |
+| `analysis(1)` → `renderer(4)` | 低→高 | **违规**（layer_direction） | 未点名（#1 只拦 renderer→analysis 方向） | 违规（仅 layer） |
+| `metrics(2)` → `analysis(1)` | 高→低 | 合法 | 未点名 | 通过 |
+
+注意第二行：**在 layers 眼里"方向合法"的依赖，被 boundary 点名后照样违规**。这是两套规则最重要的区别——boundary 是独立的黑名单，不会因为方向合法而放行。
+
+### 4.3 典型用法
+
+- **layers**：表达整体架构分层（如 core → analysis → … → app），防止基础层反向依赖上层。
+- **boundaries**：禁止"方向虽然合法、但你不想让它发生"的捷径。例如 `renderer → analysis` 方向合法，但你希望 renderer 只经由上层（app / metrics）间接使用 analysis 的能力，就把它写进 boundary。
+- **两者配合**：layer 划定大方向，boundary 补充点名禁令。反过来，如果发现某条 boundary 想禁止的依赖方向本身就是违规的（低层引高层），layer 检查会自动兜底，boundary 可以省略——但显式写上能获得更明确的报错原因（`reason` 字段会出现在违规信息里）。
+
+### 4.4 维护一致性
+
+boundary 的 `from`/`to` 是路径模式，与 layers 中定义的**层名没有引用关系**：修改某层的名称不会联动 boundary；调整某层 `paths` 覆盖范围时，也要同步检查相关 boundary 是否仍指向同样的文件集合。
+
+## 5. 路径 pattern 的写法（最容易踩的坑）
+
+### 5.1 匹配基准：相对扫描根目录的路径
+
+pattern 匹配的是**相对于扫描根目录的文件路径**。这是最容易出错的点：
+
+- 在单 crate 目录内检查时，路径形如 `src/renderer/edges.rs`，写 `"src/renderer/*"` 没问题。
+- 在**多 crate 仓库的根目录**检查（如本项目 `sentrux check .`），路径形如 `sentrux-core/src/renderer/edges.rs`，pattern 必须写成 `"sentrux-core/src/renderer/*"`。
+
+> ⚠️ **最大的坑**：pattern 前缀写错（如该带 crate 前缀却没带）**不会报任何错**——规则看起来在检查，实际上永远匹配不到任何依赖，检查静默通过。规则因此形同虚设且难以察觉。
+
+### 5.2 通配能力
+
+| 写法 | 含义 |
+|---|---|
+| `src/app.rs` | 精确匹配单个文件 |
+| `src/renderer/*` | 仅匹配该目录的**直接**子文件（不含子目录里的文件） |
+| `src/renderer/**` | 匹配该目录下**任意深度**的文件 |
+| `src/renderer` | 前缀匹配，效果近似 `src/renderer/**` |
+| `*.rs` | 按扩展名匹配任意位置的文件 |
+
+- 通配符**只能出现在尾部**：`*/src/renderer/*` 这类"中间通配"不生效。
+- 匹配区分大小写。
+- `dir/*` 与 `dir/**` 的区别要留意：前者不递归子目录。想覆盖整层就写 `dir/**`（或补全前缀后的等价形式）。
+
+### 5.3 建议的验证方法
+
+规则写好后，**主动验证它真的能命中**：
+
+1. 在规则覆盖的位置临时加一个违规 import（或新增一对文件），跑 `sentrux check`；
+2. 确认输出了对应的 `boundary` / `layer_direction` 违规；
+3. 删掉临时文件，重新确认 check 通过。
+
+也可以对照 `check` 输出的 "N rules checked"：layers 计 1 条、每条 boundary 计 1 条、启用的阈值各计 1 条。注意这个数字只说明"规则被加载了"，**不说明 pattern 能匹配到东西**——pattern 写错不会让这个数字变化。
+
+## 6. 其他注意事项
+
+- **constraints**：`max_cycles`、`max_cc`、`max_fn_lines` 等写了才启用；`no_god_files = false` 表示关闭该检查。支持 `[language.<语言名>.constraints]` 对特定语言收紧或放宽阈值。
+- **语义版本提醒**：早期版本的 order 约定与现在相反（依赖方向判定整体翻转过）。如果手上的 rules.toml 是按老版本语义写的，各层的 `order` 需要**倒序重排**，并用第 5.3 节的方法重新验证。
+- **结果解读**：所有违规均为 Error 级；只要有一条，`check` 整体失败并以非零码退出。违规信息里 `boundary` 类会附带 rules.toml 中写的 `reason`，建议每条 boundary 都写清楚理由，方便协作者理解禁令意图。

--- a/规则说明.md
+++ b/规则说明.md
@@ -9,13 +9,35 @@
 - CLI 的 `sentrux check` 与 MCP 的 `check_rules` 工具使用同一套规则文件。
 - 文件由三部分组成：
 
-| 配置段 | 作用 |
-|---|---|
-| `[constraints]` | 各类阈值（最大环数、最大圈复杂度、最大函数行数等），写了才检查 |
-| `[[layers]]` | 定义分层及 `order`，检查**依赖方向**是否违反分层约定 |
+| 配置段           | 作用                                                               |
+| ---------------- | ------------------------------------------------------------------ |
+| `[constraints]`  | 各类阈值（最大环数、最大圈复杂度、最大函数行数等），写了才检查     |
+| `[[layers]]`     | 定义分层及 `order`，检查**依赖方向**是否违反分层约定               |
 | `[[boundaries]]` | 点名禁止某类依赖（黑名单，更适用于跨层的禁止），与方向约定**无关** |
 
+**所有配置项均为可选**：不写的约束不会被检查，文件也不会因为缺字段而报错。代价是"少写一个键"和"写错一个 pattern"表现完全一样——都是静默通过（见 §5.1）。
+
+### 1.1 哪些规则会真正生效
+
+| 规则             | 生效条件                      |
+| ---------------- | ----------------------------- |
+| `min_*` 质量门限 | 对应键存在                    |
+| `max_*` 工程限制 | 对应键存在                    |
+| `no_god_files`   | 显式写 `= true`（默认 false） |
+| 分层检查         | `[[layers]]` 至少 2 条        |
+| 边界检查         | `[[boundaries]]` 存在         |
+
+`check` 退出码 0 = 全部通过，1 = 存在违规。
+
 ## 2. layers：`order` 决定"依赖方向对不对"
+
+### 2.0 字段
+
+| 字段    | 类型          | 必填 | 含义                             |
+| ------- | ------------- | ---- | -------------------------------- |
+| `name`  | string        | 是   | 层名称（如 `core`、`app`、`ui`） |
+| `paths` | array[string] | 是   | 匹配该层文件的 glob 模式列表     |
+| `order` | u32           | 否   | 层顺序，缺省时按数组位置编号     |
 
 ### 2.1 order 的约定
 
@@ -23,12 +45,14 @@
 
 以本项目的配置为例：
 
-```
+``` flow
 core=0 → analysis=1 → metrics=2 → layout=3 → renderer=4 → app=5
 ```
 
 - 合法方向：**大 order 依赖小 order**。如 `app(5)` 引 `core(0)`、`renderer(4)` 引 `analysis(1)` —— 正常。
 - 违规方向：**小 order 依赖大 order**。如 `core(0)` 引 `app(5)`、`layout(3)` 引 `app(5)` —— 报 `layer_direction` 违规。
+
+判定式：**发起方 order < 目标方 order 时触发违规**。
 
 ### 2.2 不写 order 会怎样
 
@@ -43,6 +67,14 @@ core=0 → analysis=1 → metrics=2 → layout=3 → renderer=4 → app=5
 - layer 方向违规会按违规内容去重，同类违规只报一条。
 
 ## 3. boundaries：点名禁止一条依赖
+
+### 3.0 字段
+
+| 字段     | 类型   | 必填 | 含义                                       |
+| -------- | ------ | ---- | ------------------------------------------ |
+| `from`   | string | 是   | 发起方文件的 glob 模式                     |
+| `to`     | string | 是   | 目标方文件的 glob 模式                     |
+| `reason` | string | 否   | 禁令理由，**建议必写**，会出现在违规信息里 |
 
 ### 3.1 语义
 
@@ -69,13 +101,13 @@ core=0 → analysis=1 → metrics=2 → layout=3 → renderer=4 → app=5
 
 ### 4.2 判定对照表（按本项目实际配置）
 
-| 依赖（发起方 → 目标方） | order 关系 | layers 判定 | boundaries 判定 | 最终结果 |
-|---|---|---|---|---|
-| `app(5)` → `core(0)` | 高→低 | 合法 | 未点名 | 通过 |
-| `renderer(4)` → `analysis(1)` | 高→低 | 合法 | **boundary #1 点名禁止** | **违规（boundary）** |
-| `layout(3)` → `app(5)` | 低→高 | **违规**（layer_direction） | **boundary #2 点名禁止** | **双重违规（两条都报）** |
-| `analysis(1)` → `renderer(4)` | 低→高 | **违规**（layer_direction） | 未点名（#1 只拦 renderer→analysis 方向） | 违规（仅 layer） |
-| `metrics(2)` → `analysis(1)` | 高→低 | 合法 | 未点名 | 通过 |
+| 依赖（发起方 → 目标方）       | order 关系 | layers 判定                 | boundaries 判定                          | 最终结果                 |
+| ----------------------------- | ---------- | --------------------------- | ---------------------------------------- | ------------------------ |
+| `app(5)` → `core(0)`          | 高→低      | 合法                        | 未点名                                   | 通过                     |
+| `renderer(4)` → `analysis(1)` | 高→低      | 合法                        | **boundary #1 点名禁止**                 | **违规（boundary）**     |
+| `layout(3)` → `app(5)`        | 低→高      | **违规**（layer_direction） | **boundary #2 点名禁止**                 | **双重违规（两条都报）** |
+| `analysis(1)` → `renderer(4)` | 低→高      | **违规**（layer_direction） | 未点名（#1 只拦 renderer→analysis 方向） | 违规（仅 layer）         |
+| `metrics(2)` → `analysis(1)`  | 高→低      | 合法                        | 未点名                                   | 通过                     |
 
 注意第二行：**在 layers 眼里"方向合法"的依赖，被 boundary 点名后照样违规**。这是两套规则最重要的区别——boundary 是独立的黑名单，不会因为方向合法而放行。
 
@@ -102,13 +134,14 @@ pattern 匹配的是**相对于扫描根目录的文件路径**。这是最容�
 
 ### 5.2 通配能力
 
-| 写法 | 含义 |
-|---|---|
-| `src/app.rs` | 精确匹配单个文件 |
-| `src/renderer/*` | 仅匹配该目录的**直接**子文件（不含子目录里的文件） |
-| `src/renderer/**` | 匹配该目录下**任意深度**的文件 |
-| `src/renderer` | 前缀匹配，效果近似 `src/renderer/**` |
-| `*.rs` | 按扩展名匹配任意位置的文件 |
+| 写法                | 含义                                               |
+| ------------------- | -------------------------------------------------- |
+| `src/app.rs`        | 精确匹配单个文件                                   |
+| `src/renderer/*`    | 仅匹配该目录的**直接**子文件（不含子目录里的文件） |
+| `src/renderer/**`   | 匹配该目录下**任意深度**的文件                     |
+| `src/renderer/**/*` | 与 `src/renderer/**` 等价                          |
+| `src/renderer`      | 前缀匹配，效果近似 `src/renderer/**`               |
+| `*.rs`              | 按扩展名匹配任意位置的文件                         |
 
 - 通配符**只能出现在尾部**：`*/src/renderer/*` 这类"中间通配"不生效。
 - 匹配区分大小写。
@@ -126,6 +159,132 @@ pattern 匹配的是**相对于扫描根目录的文件路径**。这是最容�
 
 ## 6. 其他注意事项
 
-- **constraints**：`max_cycles`、`max_cc`、`max_fn_lines` 等写了才启用；`no_god_files = false` 表示关闭该检查。支持 `[language.<语言名>.constraints]` 对特定语言收紧或放宽阈值。
+- **constraints**：除 `max_cycles`、`max_cc`、`max_fn_lines` 这类工程限制外，还有 `min_*` 质量门限（如 `min_quality`、`min_modularity`）与 `max_coupling_score`；`no_god_files` 默认 false，显式 `= true` 才启用。完整清单见**附录 A**，按语言收紧/放宽见**附录 C**。
 - **语义版本提醒**：早期版本的 order 约定与现在相反（依赖方向判定整体翻转过）。如果手上的 rules.toml 是按老版本语义写的，各层的 `order` 需要**倒序重排**，并用第 5.3 节的方法重新验证。
 - **结果解读**：所有违规均为 Error 级；只要有一条，`check` 整体失败并以非零码退出。违规信息里 `boundary` 类会附带 rules.toml 中写的 `reason`，建议每条 boundary 都写清楚理由，方便协作者理解禁令意图。
+
+---
+
+## 附录
+
+以下为查阅型内容，日常写规则时按需检索即可。
+
+### 附录 A：`[constraints]` 完整配置项
+
+所有键均为可选（`Option`），不写即不检查；`no_god_files` 是唯一的 `bool`，默认 `false`。
+
+#### A.1 根本原因门限（Root Cause Gates）
+
+质量维度的最小分数要求，范围 `0.0`–`1.0`。
+
+| 配置项           | 类型  | 含义                                               |
+| ---------------- | ----- | -------------------------------------------------- |
+| `min_quality`    | `f64` | 质量信号最小值（5 个根本原因维度的几何平均值）     |
+| `min_modularity` | `f64` | 模块化分数最小值（归一化的 Newman's Q）            |
+| `min_acyclicity` | `f64` | 无环性分数最小值（1.0 = 无循环依赖，0 = 完全循环） |
+| `min_depth`      | `f64` | 深度分数最小值（1.0 = 浅层架构，0 = 深层嵌套）     |
+| `min_equality`   | `f64` | 均衡性分数最小值（1.0 = 复杂度均匀分布）           |
+| `min_redundancy` | `f64` | 冗余度分数最小值（1.0 = 无死代码/重复代码）        |
+
+#### A.2 工程限制（Engineering Limits）
+
+| 配置项                  | 类型    | 默认值  | 含义                                           |
+| ----------------------- | ------- | ------- | ---------------------------------------------- |
+| `max_coupling_score`    | `f64`   | -       | 最大耦合度分数（如 `0.35`，越小越松）          |
+| `max_cycles`            | `usize` | -       | 最大允许循环依赖数量                           |
+| `max_cc`                | `u32`   | -       | 单函数最大圈复杂度                             |
+| `max_file_lines`        | `u32`   | -       | 单文件最大行数                                 |
+| `max_fn_lines`          | `u32`   | -       | 单函数最大行数                                 |
+| `no_god_files`          | `bool`  | `false` | 禁止上帝文件（Fan-out > 15），判定口径见附录 B |
+| `max_upward_violations` | `usize` | -       | 最大允许向上依赖违规数量                       |
+
+### 附录 B：Fan-in / Fan-out、God File 与 Hotspot
+
+| 指标        | 英文术语               | 定义                         | 计算                 | 含义         |
+| ----------- | ---------------------- | ---------------------------- | -------------------- | ------------ |
+| **Fan-out** | Efferent Coupling (Ce) | 该文件**依赖**了多少其他模块 | 该文件的 import 数量 | 对外依赖程度 |
+| **Fan-in**  | Afferent Coupling (Ca) | 多少其他模块**依赖**该文件   | 导入该文件的文件数量 | 被依赖程度   |
+
+Sentrux 中的用法：
+
+| 检测类型 | 使用指标             | 阈值                              | 含义                     |
+| -------- | -------------------- | --------------------------------- | ------------------------ |
+| God File | Fan-out              | > 15                              | 依赖过多其他模块         |
+| Hotspot  | Fan-in + Instability | Fan-in > 20 且 Instability ≥ 0.15 | 被大量依赖且不稳定的文件 |
+
+关键区别：**God File 看"依赖太多"（Fan-out 高），Hotspot 看"被太多依赖且不稳定"（Fan-in 高 + 不稳定性高）**。
+
+一个纯常量文件（如 `constants.ts`）即使被 38 个文件导入（高 Fan-in），只要 Fan-out 很低，就**不会**被判定为 God File。
+
+``` txt
+constants.ts -> Fan-out 低（几乎不 import） -> Fan-in 可能很高 → 不是 God File
+user-service.ts -> Fan-out 高（import 3 个模块） → 可能命中 God File
+```
+
+### 附录 C：`[language.<name>.constraints]` 语言特定约束
+
+按语言覆盖全局约束，优先级高于 `[constraints]`：
+
+```toml
+[constraints]
+max_cc = 20              # 全局默认
+
+[language.python.constraints]
+max_cc = 10              # Python 更严格
+
+[language.rust.constraints]
+max_cc = 25              # Rust 更宽松（match 分支较多）
+```
+
+只对写在该段里的键生效，未写的键沿用全局值。
+
+### 附录 D：完整示例 rules.toml
+
+> 通用示例，展示各配置段的写法；**并非本仓库的实际配置**。
+
+```toml
+[constraints]
+# 根本原因门限
+min_quality = 0.7
+min_modularity = 0.6
+min_acyclicity = 0.9
+
+# 工程限制
+max_coupling_score = 0.35
+max_cycles = 0
+max_cc = 25
+max_file_lines = 500
+max_fn_lines = 50
+no_god_files = true
+
+# 语言特定覆盖
+[language.python.constraints]
+max_cc = 15
+
+# 分层定义
+[[layers]]
+name = "core"
+paths = ["src/core/*"]
+order = 0
+
+[[layers]]
+name = "analysis"
+paths = ["src/analysis/*"]
+order = 1
+
+[[layers]]
+name = "app"
+paths = ["src/app/*"]
+order = 2
+
+[[layers]]
+name = "e2e"
+paths = ["e2e/**/*"]
+order = 3
+
+# 边界规则
+[[boundaries]]
+from = "src/app/*"
+to = "src/core/internal/*"
+reason = "App 层不能依赖核心内部模块"
+```


### PR DESCRIPTION
## Summary

This PR reverse layers.order compare logic（反转了layers.order的比较逻辑）, and add 规则说明.md to explain the params in rules.toml. It was developed on Windows 11 using AI and is **minimally tested** .

**What works after these changes:**
- lower layers order import higher layers order will violate the rule

## Changes

### 1. `sentrux-core/src/metrics/rules/mod.rs` 

- reverse the logic in layers.order compare
- add commits in boundaries compare

### 2. `sentrux-core/src/metrics/rules/tests.rs`

- add more test cases for boundaries compare

### 3. `规则说明.md` 

- 详细说明如何使用 rules.toml

## Disclaimer

These changes were developed with the assistance of AI. Use with caution and please validate on your own Windows setup before merging.